### PR TITLE
FUT-423: Publish SNS message when workflow is approved

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -135,6 +135,12 @@ const config = convict({
       default: "http://localstack:4566",
       env: "SNS_ENDPOINT"
     },
+    grantApplicationApprovedTopicArn: {
+      doc: "ARN of the SNS topic for grant application approval",
+      format: String,
+      default: "",
+      env: "SNS_GRANT_APPLICATION_APPROVED_TOPIC_ARN"
+    },
     createNewCaseSqsUrl: {
       doc: "URL of the SQS queue for case creation events",
       format: String,

--- a/src/controller/workflow.controller.js
+++ b/src/controller/workflow.controller.js
@@ -1,11 +1,21 @@
 import Boom from "@hapi/boom";
 import { extractListQuery } from "../common/helpers/api/request.js";
 import { workflowService } from "../service/workflow.service.js";
+import { snsPublisherService } from "../service/snsPublisher.js";
 
 export const workflowCreateController = async (request, h) => {
-  return h
-    .response(await workflowService.createWorkflow(request.payload, request.db))
-    .code(201);
+  const workflow = await workflowService.createWorkflow(
+    request.payload,
+    request.db
+  );
+
+  //Publishing SNS message after creation
+  await snsPublisherService.publishApplicationApproved({
+    workflowCode: workflow.workflowCode,
+    description: workflow.description
+  });
+
+  return h.response(workflow).code(201);
 };
 
 export const workflowListController = async (request, h) => {

--- a/src/controller/workflow.controller.test.js
+++ b/src/controller/workflow.controller.test.js
@@ -8,6 +8,12 @@ import {
 import { workflowService } from "../service/workflow.service.js";
 import { workflowData1 } from "../../test/fixtures/workflow.js";
 
+vi.mock("../service/snsPublisher.js", () => ({
+  snsPublisherService: {
+    publishApplicationApproved: vi.fn().mockResolvedValue(undefined)
+  }
+}));
+
 vi.mock("../service/workflow.service.js", () => ({
   workflowService: {
     createWorkflow: vi.fn(),

--- a/src/service/snsPublisher.js
+++ b/src/service/snsPublisher.js
@@ -1,0 +1,20 @@
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+import { config } from "../config.js";
+
+const snsClient = new SNSClient({
+  region: process.env.AWS_REGION,
+  endpoint: process.env.SNS_ENDPOINT
+});
+
+export const snsPublisherService = {
+  publishApplicationApproved: async (message) => {
+    const params = {
+      TopicArn: config.get("aws.grantApplicationApprovedTopicArn"),
+      Message: JSON.stringify(message)
+    };
+
+    console.log("SNS message published:", params);
+
+    await snsClient.send(new PublishCommand(params));
+  }
+};


### PR DESCRIPTION
This PR implements the functionality to publish an SNS message when a workflow is created, specifically to support the agreement generation process upon application approval.

Created grant_application_approved SNS topic in LocalStack for testing

Added snsPublisherService to publish messages to the topic

Updated workflowCreateController to trigger SNS publish post-creation

Configured topic ARN via environment variable and integrated it into the convict config

Successfully tested the integration end-to-end locally using curl and confirmed SNS publishing via logs

This change enables downstream services like the Agreement Service to subscribe to the topic and respond to workflow approvals.

<img width="585" alt="Screenshot 2025-05-07 at 11 19 11" src="https://github.com/user-attachments/assets/ef29a530-401b-40ff-87d2-37bf792aec50" />
<img width="457" alt="Screenshot 2025-05-07 at 11 19 22" src="https://github.com/user-attachments/assets/1733ea24-5972-49d4-a235-e9da84e883b3" />
