### PR TITLE
FUT-423: Add config for grant application approval SNS topic

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -115,7 +115,7 @@ const config = convict({
       doc: "ARN of the SNS topic for grant application approval",
       format: String,
       default: "",
-      env: "SNS_GRANT_APPLICATION_APPROVED_TOPIC_ARN"
+      env: "GRANT_APPLICATION_APPROVED_TOPIC_ARN"
     },
     sqsEndpoint: {
       doc: "SQS Endpoint, if not using AWS default endpoint. E.g. http://localhost:4566",

--- a/src/config.js
+++ b/src/config.js
@@ -111,6 +111,12 @@ const config = convict({
       default: "eu-west-2",
       env: "AWS_REGION"
     },
+    grantApplicationApprovedTopicArn: {
+      doc: "ARN of the SNS topic for grant application approval",
+      format: String,
+      default: "",
+      env: "SNS_GRANT_APPLICATION_APPROVED_TOPIC_ARN"
+    },
     sqsEndpoint: {
       doc: "SQS Endpoint, if not using AWS default endpoint. E.g. http://localhost:4566",
       format: String,


### PR DESCRIPTION
This PR adds configuration for the grant_application_approved SNS topic. The ARN is injected via the SNS_GRANT_APPLICATION_APPROVED_TOPIC_ARN environment variable and registered in config.js under the AWS section.

No logic for publishing to the topic is included — this change is limited to configuration only, as per ticket scope. All tests pass locally.

<img width="684" alt="Screenshot 2025-05-08 at 10 02 05" src="https://github.com/user-attachments/assets/65858861-4936-442d-965d-f80340aabd6d" />
