### PR TITLE
Feat: FUT-454 - Add agreementName to cases schema

### DIFF
--- a/src/schema/case.schema.js
+++ b/src/schema/case.schema.js
@@ -8,6 +8,7 @@ const GrantCaseEventIdentifiers = Joi.object({
 }).label("GrantCaseEventIdentifiers");
 
 const GrantCaseEventAnswers = Joi.object({
+  agreementName: Joi.string().required(),
   scheme: Joi.string().valid("SFI").required(),
   year: Joi.number().integer().min(2000).max(2100).required(),
   hasCheckedLandIsUpToDate: Joi.boolean().required(),

--- a/test/fixtures/case-list-response.json
+++ b/test/fixtures/case-list-response.json
@@ -27,6 +27,7 @@
           "defraId": "DEFRA0001"
         },
         "answers": {
+          "agreementName": "Test application name",
           "scheme": "SFI",
           "year": 2025,
           "hasCheckedLandIsUpToDate": true,
@@ -65,6 +66,7 @@
         },
         "answers": {
           "scheme": "SFI",
+          "agreementName": "Test application name",
           "year": 2025,
           "hasCheckedLandIsUpToDate": true,
           "actionApplications": [

--- a/test/fixtures/case.js
+++ b/test/fixtures/case.js
@@ -18,6 +18,7 @@ export const caseData1 = {
       defraId: "DEFRA0001"
     },
     answers: {
+      agreementName: "Test application name",
       scheme: "SFI",
       year: 2025,
       hasCheckedLandIsUpToDate: true,
@@ -56,6 +57,7 @@ export const caseData2 = {
       defraId: "DEFRA0001"
     },
     answers: {
+      agreementName: "Test application name",
       scheme: "SFI",
       year: 2025,
       hasCheckedLandIsUpToDate: true,
@@ -94,6 +96,7 @@ export const caseData3 = {
       defraId: "DEFRA0001"
     },
     answers: {
+      agreementName: "Test application name",
       scheme: "SFI",
       year: 2025,
       hasCheckedLandIsUpToDate: true,

--- a/test/fixtures/case.json
+++ b/test/fixtures/case.json
@@ -18,6 +18,7 @@
       "defraId": "DEFRA0001"
     },
     "answers": {
+      "agreementName": "Test application name",
       "scheme": "SFI",
       "year": 2025,
       "hasCheckedLandIsUpToDate": true,

--- a/test/fixtures/cases.json
+++ b/test/fixtures/cases.json
@@ -19,6 +19,7 @@
         "defraId": "DEFRA0001"
       },
       "answers": {
+        "agreementName": "Test application name 1",
         "scheme": "SFI",
         "year": 2025,
         "hasCheckedLandIsUpToDate": true,
@@ -56,6 +57,7 @@
         "defraId": "DEFRA0001"
       },
       "answers": {
+        "agreementName": "Test application name 2",
         "scheme": "SFI",
         "year": 2025,
         "hasCheckedLandIsUpToDate": true,

--- a/test/fixtures/create-case-event-1.json
+++ b/test/fixtures/create-case-event-1.json
@@ -10,6 +10,7 @@
     "defraId": "DEFRA0001"
   },
   "answers": {
+    "agreementName": "Test application name 1",
     "scheme": "SFI",
     "year": 2025,
     "hasCheckedLandIsUpToDate": true,

--- a/test/fixtures/create-case-event-3.json
+++ b/test/fixtures/create-case-event-3.json
@@ -11,6 +11,7 @@
   },
   "answers": {
     "scheme": "SFI",
+    "agreementName": "Test application name",
     "year": 2025,
     "hasCheckedLandIsUpToDate": true,
     "actionApplications": [


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/FUT/boards/1668?selectedIssue=FUT-454

- Fixes issue where applicationName was being passed as an unexpected value to case creation. This caused an error when listing cases/applications due to the field not being part of the validation.
- Add field to case schema and update tests.
- Tested using the swagger documentation endpoints on local/docker.
- Checked UI works with the updated data.

![Screenshot 2025-05-09 at 11 24 49](https://github.com/user-attachments/assets/e8a75648-0e62-401c-a1a9-451708701c50)
