### PR TITLE
move aws sns library to dependencies section

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "OGL-UK-3.0",
   "dependencies": {
     "@aws-sdk/client-sqs": "3.787.0",
+    "@aws-sdk/client-sns": "3.787.0",
     "@defra/hapi-tracing": "1.0.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/boom": "10.0.1",
@@ -59,7 +60,6 @@
     "undici": "7.7.0"
   },
   "devDependencies": {
-    "@aws-sdk/client-sns": "3.787.0",
     "@jest/globals": "29.7.0",
     "@shelf/jest-mongodb": "5.1.0",
     "@vitest/coverage-v8": "3.1.1",


### PR DESCRIPTION
Fix as not picking up the aws sns library 