### PR TITLE
Add local SNS/SQS setup script for Caseworking backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,29 @@ A local environment with:
 docker compose up --build -d
 ```
 
+## Local Messaging Setup
+
+After running `docker-compose up`, set up SNS/SQS in LocalStack by running:
+
+```bash
+./scripts/setup-local.sh
+```
+
+This will create the required SNS topics and queues for local development.
+
+#### 4. **Test it**
+
+Once LocalStack is running via Docker Compose:
+
+```bash
+./scripts/setup-local.sh
+```
+
+Then verify topics/queues exist:
+
+awslocal sns list-topics
+awslocal sqs list-queues
+
 ### Dependabot
 
 We have added an example dependabot configuration file to the repository. You can enable it by renaming

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+echo "Setting up LocalStack SNS/SQS resources for Caseworking..."
+
+# Create SNS topics
+awslocal sns create-topic --name grant-application-created
+awslocal sns create-topic --name grant_application_approved
+
+# Create queue for CW to receive messages from GAS
+awslocal sqs create-queue --queue-name create_new_case
+
+# Subscribe queue to GAS topic
+awslocal sns subscribe \
+  --topic-arn arn:aws:sns:us-east-1:000000000000:grant-application-created \
+  --protocol sqs \
+  --notification-endpoint arn:aws:sqs:us-east-1:000000000000:create_new_case
+
+echo "✅ Caseworking SNS/SQS setup complete."


### PR DESCRIPTION
This PR adds a setup-local.sh script to automate the creation of required SNS topics, SQS queues, and subscriptions for local development in the fg-cw-backend service.

 Key changes:
Created scripts/setup-local.sh to:

Create SNS topics: grant-application-created, grant_application_approved

Create SQS queue: create_new_case

Subscribe create_new_case to grant-application-created

Added usage instructions to README.md

Added test-gas-message.json to simulate incoming messages from GAS

🧪 How to test:
Run docker compose up -d

Execute ./scripts/setup-local.sh

Publish a test message:

awslocal sns publish \
  --topic-arn arn:aws:sns:us-east-1:000000000000:grant-application-created \
  --message file://test-gas-message.json

Verify the message is received:

awslocal sqs receive-message \
  --queue-url http://localhost:4566/000000000000/create_new_case

This ensures the Caseworking backend can receive and process messages from GAS as part of local end-to-end testing.