### PR TITLE
Feature/FUT-462 - Explicitly add traceId to sns event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "OGL-UK-3.0",
       "dependencies": {
+        "@aws-sdk/client-sns": "3.787.0",
         "@aws-sdk/client-sqs": "3.787.0",
         "@defra/hapi-tracing": "1.0.0",
         "@elastic/ecs-pino-format": "1.5.0",
@@ -36,7 +37,6 @@
         "undici": "7.7.0"
       },
       "devDependencies": {
-        "@aws-sdk/client-sns": "3.787.0",
         "@jest/globals": "29.7.0",
         "@shelf/jest-mongodb": "5.1.0",
         "@vitest/coverage-v8": "3.1.1",
@@ -250,7 +250,6 @@
       "version": "3.787.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.787.0.tgz",
       "integrity": "sha512-zBLiFAk7DaU7F9mjXpZvKLVTUCDYPh9/JfcYeJ4T4y2E2euc9vqQQxv6BdKx9CXzx4kXI/plVPfm5QnbhqVuNQ==",
-      "dev": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint --cache --cache-strategy content \"**/*.{cjs,js}\"",
     "lint:fix": "npm run lint -- --fix",
     "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",
-    "test": "vitest --coverage",
+    "test": "vitest",
     "test:integration": "vitest --config ./test/vitest.config.js",
     "coverage": "vitest run --coverage",
     "server:watch": "nodemon --inspect=0.0.0.0 --ext js,json --legacy-watch ./src",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint --cache --cache-strategy content \"**/*.{cjs,js}\"",
     "lint:fix": "npm run lint -- --fix",
     "postversion": "git add package.json package-lock.json && git commit -m $npm_package_version",
-    "test": "vitest",
+    "test": "vitest --coverage",
     "test:integration": "vitest --config ./test/vitest.config.js",
     "coverage": "vitest run --coverage",
     "server:watch": "nodemon --inspect=0.0.0.0 --ext js,json --legacy-watch ./src",

--- a/src/common/sns.js
+++ b/src/common/sns.js
@@ -1,19 +1,20 @@
 import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
 import { config } from "../config.js";
 import { randomUUID } from "crypto";
+import { getTraceId } from "@defra/hapi-tracing";
 
 const region = config.get("aws.awsRegion") || "eu-west-2";
 const endpoint = config.get("aws.snsEndpoint") || "http://localhost:4566";
 
 export const snsClient = new SNSClient({ region, endpoint });
 
-export const publish = async (topicArn, message, traceId) => {
+export const publish = async (topicArn, message) => {
   const event = {
     id: randomUUID(),
     source: config.get("serviceName"),
     specVersion: "1.0",
     type: `cloud.defra.${config.get("cdpEnvironment")}.${config.get("serviceName")}.case.stage.updated`,
-    data: { ...message, traceId }
+    data: { ...message, traceId: getTraceId() }
   };
 
   return snsClient.send(

--- a/src/common/sns.js
+++ b/src/common/sns.js
@@ -7,13 +7,13 @@ const endpoint = config.get("aws.snsEndpoint") || "http://localhost:4566";
 
 export const snsClient = new SNSClient({ region, endpoint });
 
-export const publish = async (topicArn, message) => {
+export const publish = async (topicArn, message, traceId) => {
   const event = {
     id: randomUUID(),
     source: config.get("serviceName"),
     specVersion: "1.0",
     type: `cloud.defra.${config.get("cdpEnvironment")}.${config.get("serviceName")}.case.stage.updated`,
-    data: message
+    data: { ...message, traceId }
   };
 
   return snsClient.send(

--- a/src/common/sns.js
+++ b/src/common/sns.js
@@ -1,22 +1,12 @@
 import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
 import { config } from "../config.js";
-import { randomUUID } from "crypto";
-import { getTraceId } from "@defra/hapi-tracing";
 
 const region = config.get("aws.awsRegion") || "eu-west-2";
 const endpoint = config.get("aws.snsEndpoint") || "http://localhost:4566";
 
 export const snsClient = new SNSClient({ region, endpoint });
 
-export const publish = async (topicArn, message) => {
-  const event = {
-    id: randomUUID(),
-    source: config.get("serviceName"),
-    specVersion: "1.0",
-    type: `cloud.defra.${config.get("cdpEnvironment")}.${config.get("serviceName")}.case.stage.updated`,
-    data: { ...message, traceParent: getTraceId() }
-  };
-
+export const publish = async (topicArn, event) => {
   return snsClient.send(
     new PublishCommand({
       Message: JSON.stringify(event),

--- a/src/common/sns.js
+++ b/src/common/sns.js
@@ -14,7 +14,7 @@ export const publish = async (topicArn, message) => {
     source: config.get("serviceName"),
     specVersion: "1.0",
     type: `cloud.defra.${config.get("cdpEnvironment")}.${config.get("serviceName")}.case.stage.updated`,
-    data: { ...message, traceId: getTraceId() }
+    data: { ...message, traceParent: getTraceId() }
   };
 
   return snsClient.send(

--- a/src/common/sns.js
+++ b/src/common/sns.js
@@ -1,5 +1,6 @@
 import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
 import { config } from "../config.js";
+import { getTraceId } from "@defra/hapi-tracing";
 
 const region = config.get("aws.awsRegion") || "eu-west-2";
 const endpoint = config.get("aws.snsEndpoint") || "http://localhost:4566";
@@ -9,7 +10,7 @@ export const snsClient = new SNSClient({ region, endpoint });
 export const publish = async (topicArn, event) => {
   return snsClient.send(
     new PublishCommand({
-      Message: JSON.stringify(event),
+      Message: JSON.stringify({ ...event, traceparent: getTraceId() }),
       TopicArn: topicArn
     })
   );

--- a/src/common/sns.test.js
+++ b/src/common/sns.test.js
@@ -1,0 +1,17 @@
+import { describe, test, expect, vi } from "vitest";
+import * as sns from "./sns";
+
+describe("sns", () => {
+  test("publishes an event", async () => {
+    const snsSendSpy = vi
+      .spyOn(sns.snsClient, "send")
+      .mockImplementation(() => {});
+    const topicArn = "some-topic-id";
+    const event = {
+      body: { key: "value " }
+    };
+
+    await sns.publish(topicArn, event);
+    expect(snsSendSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/src/controller/case.controller.js
+++ b/src/controller/case.controller.js
@@ -3,6 +3,7 @@ import { caseService } from "../service/case.service.js";
 import { extractListQuery } from "../common/helpers/api/request.js";
 import { publish } from "../common/sns.js";
 import { config } from "../config.js";
+import { getTraceId } from "@defra/hapi-tracing";
 
 export const caseCreateController = async (request, h) => {
   return h
@@ -32,6 +33,7 @@ export const caseDetailController = async (request, h) => {
 
 export const caseStageController = async (request, h) => {
   const { caseId } = request.params;
+  const traceId = getTraceId();
 
   const caseRecord = await caseService.getCase(caseId, request.db);
   if (!caseRecord) {
@@ -43,11 +45,15 @@ export const caseStageController = async (request, h) => {
 
   await caseService.updateCaseStage(caseId, nextStage, request.db);
 
-  await publish(config.get("aws.caseStageUpdatedTopicArn"), {
-    caseRef: caseRecord.caseRef,
-    previousStage,
-    currentStage: nextStage
-  });
+  await publish(
+    config.get("aws.caseStageUpdatedTopicArn"),
+    {
+      caseRef: caseRecord.caseRef,
+      previousStage,
+      currentStage: nextStage
+    },
+    traceId
+  );
 
   return h.response().code(204);
 };

--- a/src/controller/case.controller.js
+++ b/src/controller/case.controller.js
@@ -1,6 +1,5 @@
 import Boom from "@hapi/boom";
 import { randomUUID } from "crypto";
-import { getTraceId } from "@defra/hapi-tracing";
 import { caseService } from "../service/case.service.js";
 import { extractListQuery } from "../common/helpers/api/request.js";
 import { publish } from "../common/sns.js";
@@ -54,8 +53,7 @@ export const caseStageController = async (request, h) => {
       caseRef: caseRecord.caseRef,
       previousStage,
       currentStage: nextStage
-    },
-    traceparent: getTraceId()
+    }
   };
 
   await publish(config.get("aws.caseStageUpdatedTopicArn"), event);

--- a/src/controller/case.controller.js
+++ b/src/controller/case.controller.js
@@ -1,4 +1,6 @@
 import Boom from "@hapi/boom";
+import { randomUUID } from "crypto";
+import { getTraceId } from "@defra/hapi-tracing";
 import { caseService } from "../service/case.service.js";
 import { extractListQuery } from "../common/helpers/api/request.js";
 import { publish } from "../common/sns.js";
@@ -43,11 +45,20 @@ export const caseStageController = async (request, h) => {
 
   await caseService.updateCaseStage(caseId, nextStage, request.db);
 
-  await publish(config.get("aws.caseStageUpdatedTopicArn"), {
-    caseRef: caseRecord.caseRef,
-    previousStage,
-    currentStage: nextStage
-  });
+  const event = {
+    id: randomUUID(),
+    source: config.get("serviceName"),
+    specVersion: "1.0",
+    type: `cloud.defra.${config.get("cdpEnvironment")}.${config.get("serviceName")}.case.stage.updated`,
+    data: {
+      caseRef: caseRecord.caseRef,
+      previousStage,
+      currentStage: nextStage
+    },
+    traceparent: getTraceId()
+  };
+
+  await publish(config.get("aws.caseStageUpdatedTopicArn"), event);
 
   return h.response().code(204);
 };


### PR DESCRIPTION
Adds trace id to the sns event.
I added this as an explicit parameter rather than to the message body so it is clear to consumers that it should be passed.

Part of:  https://eaflood.atlassian.net/browse/FUT-462 
Requires: https://github.com/DEFRA/fg-cw-frontend/pull/28