### PR TITLE
update the case and workflow definitions

### DIFF
--- a/test/fixtures/pmf-case.json
+++ b/test/fixtures/pmf-case.json
@@ -15,9 +15,9 @@
       "isPigFarmer": true,
       "totalPigs": 10,
       "whitePigsCount": 2,
-      "britishLandraceCount": 2,
-      "berkshireCount": 3,
-      "otherCount": 3
+      "britishLandracePigsCount": 2,
+      "berkshirePigsCount": 3,
+      "otherPigsCount": 3
     }
   },
   "currentStage": "application-received",

--- a/test/fixtures/pmf-workflow-definition.json
+++ b/test/fixtures/pmf-workflow-definition.json
@@ -17,15 +17,15 @@
           "type": "integer",
           "label": "How many white pigs do you have?"
         },
-        "britishLandraceCount": {
+        "britishLandracePigsCount": {
           "type": "integer",
           "label": "How many British Landrace pigs do you have?"
         },
-        "berkshireCount": {
+        "berkshirePigsCount": {
           "type": "integer",
           "label": "How many Berkshire pigs do you have?"
         },
-        "otherCount": {
+        "otherPigsCount": {
           "type": "integer",
           "label": "How many other pigs do you have?"
         }


### PR DESCRIPTION
Following props names are updated to match grant definition

- "totalPigs"
- "whitePigsCount"
- "britishLandracePigsCount":
- "berkshirePigsCount"
- "otherPigsCount"