### PR TITLE
Feat: FUT-532 Filter cases based on authenticated user's roles

### DIFF
--- a/src/cases/repositories/workflow.repository.js
+++ b/src/cases/repositories/workflow.repository.js
@@ -37,14 +37,26 @@ export const save = async (workflow) => {
   }
 };
 
-export const findAll = async (query) => {
+// eslint-disable-next-line complexity
+export const createWorkflowFilter = (query = {}) => {
+  const { codes, $expr } = query;
   const filter = {};
 
-  if (query?.codes?.length) {
+  if (codes?.length) {
     filter.code = {
-      $in: query.codes,
+      $in: codes,
     };
   }
+
+  if ($expr) {
+    filter.$expr = $expr;
+  }
+
+  return filter;
+};
+
+export const findAll = async (query) => {
+  const filter = createWorkflowFilter(query);
 
   const workflowDocuments = await db
     .collection(collection)

--- a/src/cases/use-cases/find-cases.use-case.js
+++ b/src/cases/use-cases/find-cases.use-case.js
@@ -1,35 +1,70 @@
+import { getAuthenticatedUserRoles } from "../../common/auth.js";
 import { findUsersUseCase } from "../../users/use-cases/find-users.use-case.js";
 import { findAll } from "../repositories/case.repository.js";
 import { findWorkflowsUseCase } from "./find-workflows.use-case.js";
 
+export const createUserRolesFilter = (userRoles, extrafilters = {}) => {
+  // Checks if all roles are in userRoles.
+  const allOf = {
+    $setIsSubset: ["$requiredRoles.allOf", userRoles],
+  };
+
+  // Checks any (more than one) are in userRoles.
+  const anyOf = {
+    $gt: [
+      {
+        $size: { $setIntersection: ["$requiredRoles.anyOf", userRoles] },
+      },
+      0,
+    ],
+  };
+
+  return {
+    $expr: {
+      $and: [allOf, anyOf, extrafilters],
+    },
+  };
+};
+
 export const findCasesUseCase = async () => {
+  const userRoles = getAuthenticatedUserRoles();
   const cases = await findAll();
 
   const assignedUserIds = cases.map((c) => c.assignedUser?.id).filter(Boolean);
   const workflowCodes = cases.map((c) => c.workflowCode);
 
+  // Filter workflows by user roles and case workflow codes.
+  const workflowFilter = createUserRolesFilter(userRoles, {
+    codes: workflowCodes,
+  });
+
   const [users, workflows] = await Promise.all([
     findUsersUseCase({
       ids: assignedUserIds,
     }),
-    findWorkflowsUseCase({
-      codes: workflowCodes,
-    }),
+    findWorkflowsUseCase(workflowFilter),
   ]);
 
-  for (const kase of cases) {
-    const assignedUser = users.find((u) => u.id === kase.assignedUser?.id);
-
-    if (assignedUser) {
-      kase.assignedUser.name = assignedUser.name;
-    }
-
+  // Remove any cases that the user does not have access to
+  const casesFiltered = cases.reduce((acc, kase) => {
     const workflow = workflows.find((w) => w.code === kase.workflowCode);
 
+    // We only add cases if there's a workflow that was filtered above.
     if (workflow) {
       kase.requiredRoles = workflow.requiredRoles;
-    }
-  }
 
-  return cases;
+      // Only then do we look up the assigned user.
+      const assignedUser = users.find((u) => u.id === kase.assignedUser?.id);
+
+      if (assignedUser) {
+        kase.assignedUser.name = assignedUser.name;
+      }
+      acc.push(kase);
+      return acc;
+    } else {
+      return acc;
+    }
+  }, []);
+
+  return casesFiltered;
 };

--- a/src/common/auth.js
+++ b/src/common/auth.js
@@ -1,0 +1,7 @@
+// TODO: this is a stub. Replace when auth has been implemented.
+export const getAuthenticatedUserRoles = () => [
+  "ROLE_RPA",
+  "ROLE_FLYING_PIGS",
+  "ROLE_LEVEL_1",
+  "ROLE_LEVEL_2",
+];

--- a/src/common/auth.test.js
+++ b/src/common/auth.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getAuthenticatedUserRoles } from "./auth.js";
+
+describe("auth - getAuthenticatedUserRoles", () => {
+  it("should return roles", () => {
+    expect(getAuthenticatedUserRoles()).toEqual([
+      "ROLE_RPA",
+      "ROLE_FLYING_PIGS",
+      "ROLE_LEVEL_1",
+      "ROLE_LEVEL_2",
+    ]);
+  });
+});


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/FUT/boards/1668?selectedIssue=FUT-532

- use the authenticated user's roles to fetch workflows (stubbed functionality\*)
- then filter the cases based on the above results (if no workflow is returned, do not pass the related case(s) back to fe)

\* I've stubbed the authenticated user roles until we get the auth work in.