### PR TITLE
fix: remove encoding of text

### DIFF
--- a/src/cases/models/comment.js
+++ b/src/cases/models/comment.js
@@ -18,8 +18,7 @@ export class Comment {
   });
 
   constructor(props) {
-    const { encode, ...rest } = props;
-    const { error, value } = Comment.validationSchema.validate(rest, {
+    const { error, value } = Comment.validationSchema.validate(props, {
       stripUnknown: true,
       abortEarly: false,
     });
@@ -32,13 +31,9 @@ export class Comment {
 
     this.ref = value.ref || new ObjectId().toHexString();
     this.type = value.type;
-    this.text = this.safeEncodeText(value.text, encode);
+    this.text = value.text;
     this.createdBy = value.createdBy;
     this.createdAt = value.createdAt || new Date().toISOString();
-  }
-
-  safeEncodeText(text, encode = true) {
-    return encode ? encodeURIComponent(text) : text;
   }
 
   getUserIds() {
@@ -81,7 +76,7 @@ export class Comment {
  * @returns
  */
 export const toComment = (props) => {
-  return new Comment({ ...props, encode: false });
+  return new Comment(props);
 };
 
 export const toComments = (props) => {

--- a/src/cases/models/comment.test.js
+++ b/src/cases/models/comment.test.js
@@ -22,7 +22,7 @@ describe("Comment", () => {
 
       expect(comment.ref).toBe("64c88faac1f56f71e1b89a33");
       expect(comment.type).toBe("NOTE_ADDED");
-      expect(comment.text).toBe("Test%20comment%20text");
+      expect(comment.text).toBe("Test comment text");
       expect(comment.createdBy).toBe("user-123");
       expect(comment.createdAt).toBe("2025-01-01T00:00:00.000Z");
     });
@@ -184,20 +184,6 @@ describe("toComment", () => {
     expect(comment.type).toBe("NOTE_ADDED");
     expect(comment.text).toBe("Test comment text");
     expect(comment.createdBy).toBe("user-123");
-  });
-
-  it("should not attempt to re-encode comment text after creation", () => {
-    const props = {
-      type: "NOTE_ADDED",
-      text: "Test comment text",
-      createdBy: "user-123",
-    };
-
-    const comment = new Comment(props);
-    expect(comment.text).toBe("Test%20comment%20text");
-
-    const comment2 = toComment(comment);
-    expect(comment2.text).toBe("Test%20comment%20text");
   });
 });
 

--- a/src/cases/use-cases/add-note-to-case.use-case.test.js
+++ b/src/cases/use-cases/add-note-to-case.use-case.test.js
@@ -29,7 +29,7 @@ describe("addNoteToCaseUseCase", () => {
 
     expect(result).toBeInstanceOf(Comment);
     expect(result.type).toBe("NOTE_ADDED");
-    expect(result.text).toBe("This%20is%20a%20test%20note");
+    expect(result.text).toBe("This is a test note");
     expect(result.createdBy).toBe("user-123");
     expect(result.ref).toBeDefined();
     expect(result.createdAt).toBeDefined();
@@ -54,7 +54,7 @@ describe("addNoteToCaseUseCase", () => {
     const result = await addNoteToCaseUseCase(command);
 
     expect(result.type).toBe("TASK_COMPLETED");
-    expect(result.text).toBe("Task%20has%20been%20completed");
+    expect(result.text).toBe("Task has been completed");
     expect(result.createdBy).toBe("user-456");
   });
 


### PR DESCRIPTION
nunjucks and mongo handle any erroneous strings - we don’t need to encode text