### PR TITLE
Update `publish.yml` to use Node version specified in `.nvmrc`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
 
+      - name: Use Node version
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
       - name: Build and Publish
         uses: DEFRA/cdp-build-action/build@main
         with:


### PR DESCRIPTION
Update `publish.yml` to use same version of node as the app to prevent test coverage failure in the build.