### PR TITLE
FGP-1051: remove duplicate "Reason for termination" heading

### DIFF
--- a/migrations/20260519095606-update-termination-label.js
+++ b/migrations/20260519095606-update-termination-label.js
@@ -2,19 +2,35 @@ export const up = async (db) => {
   const terminationComment = {
     label: {
       text: "Reason for termination",
-      classes: "",
+      classes: "govuk-label--s",
     },
     helpText: "You must include an explanation for auditing purposes.",
     mandatory: true,
   };
 
-  await db.collection("workflows").updateOne(
-    { code: "frps-private-beta" },
-    {
-      $set: {
-        "phases.1.stages.0.statuses.0.transitions.0.action.comment":
-          terminationComment,
-      },
+  const workflow = await db
+    .collection("workflows")
+    .findOne({ code: "frps-private-beta" });
+
+  if (!workflow) {
+    return;
+  }
+
+  const content =
+    workflow.phases?.[1]?.stages?.[0]?.beforeContent?.[0]?.content;
+
+  const update = {
+    $set: {
+      "phases.1.stages.0.statuses.0.transitions.0.action.comment":
+        terminationComment,
     },
-  );
+  };
+
+  if (content?.length === 6) {
+    update.$pop = { "phases.1.stages.0.beforeContent.0.content": 1 };
+  }
+
+  await db
+    .collection("workflows")
+    .updateOne({ code: "frps-private-beta" }, update);
 };

--- a/migrations/20260519095606-update-termination-label.js
+++ b/migrations/20260519095606-update-termination-label.js
@@ -1,0 +1,20 @@
+export const up = async (db) => {
+  const terminationComment = {
+    label: {
+      text: "Reason for termination",
+      classes: "",
+    },
+    helpText: "You must include an explanation for auditing purposes.",
+    mandatory: true,
+  };
+
+  await db.collection("workflows").updateOne(
+    { code: "frps-private-beta" },
+    {
+      $set: {
+        "phases.1.stages.0.statuses.0.transitions.0.action.comment":
+          terminationComment,
+      },
+    },
+  );
+};

--- a/src/cases/models/workflow-task-comment.test.js
+++ b/src/cases/models/workflow-task-comment.test.js
@@ -13,4 +13,21 @@ describe("WorkflowTaskComment", () => {
     expect(comment.helpText).toBe("Please provide details");
     expect(comment.mandatory).toBe(true);
   });
+
+  it("should create a workflow task comment with an object label", () => {
+    const comment = new WorkflowTaskComment({
+      label: { text: "Reason for termination", classes: "govuk-label--s" },
+      helpText: "You must include an explanation for auditing purposes.",
+      mandatory: true,
+    });
+
+    expect(comment.label).toEqual({
+      text: "Reason for termination",
+      classes: "govuk-label--s",
+    });
+    expect(comment.helpText).toBe(
+      "You must include an explanation for auditing purposes.",
+    );
+    expect(comment.mandatory).toBe(true);
+  });
 });

--- a/src/cases/schemas/comment.schema.js
+++ b/src/cases/schemas/comment.schema.js
@@ -1,7 +1,15 @@
 import Joi from "joi";
 
 export const comment = Joi.object({
-  label: Joi.string().required(),
+  label: Joi.alternatives()
+    .try(
+      Joi.string(),
+      Joi.object({
+        text: Joi.string().required(),
+        classes: Joi.string().optional(),
+      }),
+    )
+    .required(),
   helpText: Joi.string().required(),
   mandatory: Joi.boolean().required(),
 }).label("Comment");

--- a/src/cases/schemas/task.schema.test.js
+++ b/src/cases/schemas/task.schema.test.js
@@ -73,6 +73,24 @@ describe("Task Schema", () => {
     expect(error.details[0].message).toBe('"comment.mandatory" is required');
   });
 
+  it("should allow object label in comment", () => {
+    const task = {
+      code: "TASK_1",
+      name: "Test task",
+      description: null,
+      mandatory: true,
+      statusOptions: [],
+      comment: {
+        label: { text: "Reason for termination", classes: "govuk-label--s" },
+        helpText: "You must include an explanation for auditing purposes.",
+        mandatory: true,
+      },
+    };
+
+    const { error } = Task.validate(task);
+    expect(error).toBeUndefined();
+  });
+
   it("should allow null comment", () => {
     const task = {
       code: "TASK_1",


### PR DESCRIPTION
Adds a migration to:
- remove the heading "Reason for termination"
- adds classes to label to style as heading

Needs: https://github.com/DEFRA/fg-cw-frontend/pull/371

https://eaflood.atlassian.net/browse/FGP-1051

<img width="1094" height="1306" alt="Screenshot 2026-05-19 at 13 35 58" src="https://github.com/user-attachments/assets/80823b73-caa7-463e-8001-1e5cf8b25b0b" />
