### PR TITLE
FGP-1078: add migration to override classes

### DIFF
--- a/migrations/20260520145247-remove-calculation-underline.js
+++ b/migrations/20260520145247-remove-calculation-underline.js
@@ -1,0 +1,22 @@
+export const up = async (db) => {
+  const workflow = await db
+    .collection("workflows")
+    .findOne({ code: "frps-private-beta" });
+
+  if (!workflow) {
+    return;
+  }
+
+  const currentClasses =
+    workflow.pages.cases.details.tabs.calculations.content[1].whenTrue.items[2]
+      .classes;
+
+  await db.collection("workflows").updateOne(
+    { code: "frps-private-beta" },
+    {
+      $set: {
+        "pages.cases.details.tabs.calculations.content.1.whenTrue.items.2.classes": `${currentClasses} no-underline`,
+      },
+    },
+  );
+};


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-1078

Needs: https://github.com/DEFRA/fg-cw-frontend/pull/372

Prevents details component in calculations styling the toggle as a link.
Had to add the override class higher up the DOM as we couldn't access the internal css from the config.\

<img width="1069" height="1139" alt="Screenshot 2026-05-20 at 15 46 15" src="https://github.com/user-attachments/assets/ea4953b1-30a0-4440-b58a-54773200b6ce" />
