### PR TITLE
chore(NO-JIRA): Updating dependabot flagged packages which are low risk

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: github.actor != 'dependabot[bot]'
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm run test:unit -- --coverage
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           npm run test:unit -- --coverage
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "jsonpath-plus": "10.4.0",
         "migrate-mongo": "14.0.7",
         "mongodb": "7.1.0",
-        "pino": "10.3.0",
+        "pino": "10.3.1",
         "pino-pretty": "13.1.3"
       },
       "devDependencies": {
@@ -46,7 +46,7 @@
         "husky": "9.1.7",
         "lint-staged": "16.2.7",
         "neostandard": "0.12.2",
-        "nodemon": "3.1.11",
+        "nodemon": "3.1.14",
         "prettier": "3.8.1",
         "prettier-plugin-organize-imports": "4.3.0",
         "testcontainers": "^11.11.0",
@@ -2184,9 +2184,9 @@
       }
     },
     "node_modules/@hapi/wreck": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.0.tgz",
-      "integrity": "sha512-0z6ZRCmFEfV/MQqkQomJ7sl/hyxvcZM7LtuVqN3vdAO4vM9eBbowl0kaqQj9EJJQab+3Uuh1GxbGIBFy4NfJ4w==",
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/@hapi/wreck/-/wreck-18.1.2.tgz",
+      "integrity": "sha512-3dMnV2pfhQiyEqu8DL3VBmxkdLiRDiiUDuG79Dp+UK1gL9ZxAfDOUhB6k3D5MLqcgJJ1IARyGFhwoc1NITr/pg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
@@ -9561,16 +9561,16 @@
       }
     },
     "node_modules/nodemon": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
-      "integrity": "sha512-is96t8F/1//UHAjNPHpbsNY46ELPpftGUoSVNXwUfMk/qdjSylYrWSu1XavVTBOn526kFiOR733ATgNBCQyH0g==",
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.2",
         "debug": "^4",
         "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.1",
         "pstree.remy": "^1.1.8",
         "semver": "^7.5.3",
         "simple-update-notifier": "^2.0.0",
@@ -9589,6 +9589,29 @@
         "url": "https://opencollective.com/nodemon"
       }
     },
+    "node_modules/nodemon/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/nodemon/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/nodemon/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -9597,6 +9620,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/nodemon/node_modules/supports-color": {
@@ -10021,9 +10060,9 @@
       }
     },
     "node_modules/pino": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.0.tgz",
-      "integrity": "sha512-0GNPNzHXBKw6U/InGe79A3Crzyk9bcSyObF9/Gfo9DLEf5qj5RF50RSjsu0W1rZ6ZqRGdzDFCRBQvi9/rSGPtA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "jsonpath-plus": "10.4.0",
     "migrate-mongo": "14.0.7",
     "mongodb": "7.1.0",
-    "pino": "10.3.0",
+    "pino": "10.3.1",
     "pino-pretty": "13.1.3"
   },
   "devDependencies": {
@@ -73,7 +73,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.2.7",
     "neostandard": "0.12.2",
-    "nodemon": "3.1.11",
+    "nodemon": "3.1.14",
     "prettier": "3.8.1",
     "prettier-plugin-organize-imports": "4.3.0",
     "testcontainers": "^11.11.0",


### PR DESCRIPTION
pino 10.3.0 → 10.3.1 
Patch release. No API changes.

nodemon 3.1.11 → 3.1.14 
Patch release. Dev-only dependency.

@hapi/wreck 18.1.0 → 18.1.2 
Patch release. No API changes.

SonarSource/sonarqube-scan-action 8.0.0 → 8.2.0 
CI tooling only.