### PR TITLE
feat(FGP-1179): Refactoring beforeContent and adding afterContent

### DIFF
--- a/migrations/20260618120000-cleanup-before-content-render-if.js
+++ b/migrations/20260618120000-cleanup-before-content-render-if.js
@@ -1,0 +1,41 @@
+export const up = async (db) => {
+  await db.collection("workflows").updateOne(
+    { code: "woodland" },
+    {
+      $set: {
+        "phases.0.stages.0.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'STATUS_APPLICATION_IN_REVIEW'",
+        "phases.0.stages.0.beforeContent.1.renderIf":
+          "jsonata:$.position.statusCode = 'STATUS_APPLICATION_RECEIVED'",
+        "phases.0.stages.0.beforeContent.2.renderIf":
+          "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_GENERATING'",
+        "phases.0.stages.1.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_READY_FOR_APPLICANT'",
+        "phases.0.stages.2.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_OFFERED'",
+        "phases.0.stages.4.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'STATUS_APPLICATION_AWAITING_FC'",
+      },
+    },
+  );
+
+  await db.collection("workflows").updateOne(
+    { code: "frps" },
+    {
+      $set: {
+        "phases.0.stages.0.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'APPLICATION_AMEND'",
+        "phases.0.stages.1.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'APPLICATION_AMEND'",
+        "phases.0.stages.2.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'AGREEMENT_OFFERED'",
+        "phases.0.stages.2.beforeContent.1.renderIf":
+          "jsonata:$.position.statusCode = 'APPLICATION_AMEND'",
+        "phases.1.stages.0.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'AGREEMENT_ACCEPTED'",
+        "phases.1.stages.1.beforeContent.0.renderIf":
+          "jsonata:$.position.statusCode = 'AGREEMENT_TERMINATED'",
+      },
+    },
+  );
+};

--- a/src/cases/models/workflow-stage.js
+++ b/src/cases/models/workflow-stage.js
@@ -8,6 +8,7 @@ export class WorkflowStage {
     this.statuses = props.statuses;
     this.taskGroups = props.taskGroups;
     this.beforeContent = props.beforeContent || [];
+    this.afterContent = props.afterContent || [];
   }
 
   findTaskGroup(taskGroupCode) {

--- a/src/cases/repositories/workflow.repository.js
+++ b/src/cases/repositories/workflow.repository.js
@@ -103,6 +103,7 @@ const toWorkflowStage = (s) =>
     statuses: s.statuses.map(toWorkflowStageStatus),
     taskGroups: s.taskGroups.map(toWorkflowTaskGroup),
     beforeContent: s.beforeContent,
+    afterContent: s.afterContent,
   });
 
 const toWorkflowPhase = (p) =>

--- a/src/cases/repositories/workflow/stage-document.js
+++ b/src/cases/repositories/workflow/stage-document.js
@@ -6,6 +6,8 @@ export class StageDocument {
     this.code = props.code;
     this.name = props.name;
     this.description = props.description;
+    this.beforeContent = props.beforeContent;
+    this.afterContent = props.afterContent;
     this.statuses = props.statuses.map((status) => new StatusDocument(status));
     this.taskGroups = props.taskGroups.map(
       (taskGroup) => new TaskGroupDocument(taskGroup),

--- a/src/cases/routes/find-case-by-id-tab-id.route.test.js
+++ b/src/cases/routes/find-case-by-id-tab-id.route.test.js
@@ -69,7 +69,6 @@ describe("findCaseByIdTabIdRoute", () => {
           ],
         },
       ],
-      beforeContent: [],
     };
 
     buildCaseDetailsTabUseCase.mockResolvedValueOnce(mockTabData);

--- a/src/cases/schemas/task.schema.js
+++ b/src/cases/schemas/task.schema.js
@@ -94,6 +94,7 @@ export const Stage = Joi.object({
   statuses: Joi.array().items(Status).required(),
   agreements: Joi.array().optional().allow(null),
   beforeContent: Joi.array().items(componentSchema).optional(),
+  afterContent: Joi.array().items(componentSchema).optional(),
 }).label("Stage");
 
 export const Phase = Joi.object({

--- a/src/cases/use-cases/build-case-details-tab.use-case.js
+++ b/src/cases/use-cases/build-case-details-tab.use-case.js
@@ -140,7 +140,7 @@ const getActionContext = async ({ tabDefinition, caseWorkflowContext }) => {
 };
 
 const buildContent = async (root) => {
-  return await resolveJSONPath({
+  return resolveJSONPath({
     root,
     path: root.tabDefinition.content,
   });

--- a/src/cases/use-cases/build-case-details-tab.use-case.js
+++ b/src/cases/use-cases/build-case-details-tab.use-case.js
@@ -11,7 +11,6 @@ import { logger } from "../../common/logger.js";
 import { resolveJSONPath } from "../../common/resolve-json.js";
 import { findById } from "../repositories/case.repository.js";
 import { findByCode } from "../repositories/workflow.repository.js";
-import { buildBeforeContent } from "./build-before-content.js";
 import { externalActionUseCase } from "./external-action.use-case.js";
 
 export const buildCaseDetailsTabUseCase = async (request) => {
@@ -44,13 +43,10 @@ export const buildCaseDetailsTabUseCase = async (request) => {
     user,
   });
 
-  const workflowStage = workflow.getStage(kase.position);
-
-  const [banner, links, content, beforeContent] = await Promise.all([
+  const [banner, links, content] = await Promise.all([
     buildBanner(root),
     buildLinks(root),
     buildContent(root),
-    buildBeforeContent(workflowStage, root),
   ]);
 
   logger.info(
@@ -64,7 +60,6 @@ export const buildCaseDetailsTabUseCase = async (request) => {
     banner,
     links,
     content,
-    beforeContent,
   };
 };
 

--- a/src/cases/use-cases/build-case-details-tab.use-case.test.js
+++ b/src/cases/use-cases/build-case-details-tab.use-case.test.js
@@ -49,6 +49,7 @@ describe("buildCaseDetailsTabUseCase", () => {
     expect(result.content).toBeDefined();
     expect(Array.isArray(result.content)).toBe(true);
     expect(result.content[0].title).toBe("Details");
+    expect(result.beforeContent).toBeUndefined();
   });
 
   it("throws error when case not found", async () => {

--- a/src/cases/use-cases/build-stage-content.js
+++ b/src/cases/use-cases/build-stage-content.js
@@ -3,7 +3,7 @@ import { resolveJSONPath } from "../../common/resolve-json.js";
 
 const shouldRenderItem = async (item, caseWorkflowContext) => {
   if (!item.renderIf) {
-    logger.info("[beforeContent] No renderIf condition, defaulting to true");
+    logger.info("[stageContent] No renderIf condition, defaulting to true");
     return true;
   }
 
@@ -21,7 +21,7 @@ const resolveContentItem = async (item, caseWorkflowContext) => {
   return Array.isArray(content) ? content : [content];
 };
 
-const processBeforeContentItem = async (item, caseWorkflowContext) => {
+const processStageContentItem = async (item, caseWorkflowContext) => {
   const shouldRender = await shouldRenderItem(item, caseWorkflowContext);
   if (!shouldRender) {
     return [];
@@ -29,17 +29,18 @@ const processBeforeContentItem = async (item, caseWorkflowContext) => {
   return await resolveContentItem(item, caseWorkflowContext);
 };
 
-export const buildBeforeContent = async (
-  workflowStage,
-  caseWorkflowContext,
-) => {
-  const beforeContentDefs = workflowStage.beforeContent || [];
+const buildContent = async (items, caseWorkflowContext) => {
+  if (!items) return [];
 
   const resolvedItems = await Promise.all(
-    beforeContentDefs.map((item) =>
-      processBeforeContentItem(item, caseWorkflowContext),
-    ),
+    items.map((item) => processStageContentItem(item, caseWorkflowContext)),
   );
 
   return resolvedItems.flat();
 };
+
+export const buildBeforeContent = (workflowStage, caseWorkflowContext) =>
+  buildContent(workflowStage.beforeContent, caseWorkflowContext);
+
+export const buildAfterContent = (workflowStage, caseWorkflowContext) =>
+  buildContent(workflowStage.afterContent, caseWorkflowContext);

--- a/src/cases/use-cases/build-stage-content.js
+++ b/src/cases/use-cases/build-stage-content.js
@@ -7,7 +7,7 @@ const shouldRenderItem = async (item, caseWorkflowContext) => {
     return true;
   }
 
-  return await resolveJSONPath({
+  return resolveJSONPath({
     root: caseWorkflowContext,
     path: item.renderIf,
   });
@@ -30,7 +30,9 @@ const processStageContentItem = async (item, caseWorkflowContext) => {
 };
 
 const buildContent = async (items, caseWorkflowContext) => {
-  if (!items) return [];
+  if (!items) {
+    return [];
+  }
 
   const resolvedItems = await Promise.all(
     items.map((item) => processStageContentItem(item, caseWorkflowContext)),

--- a/src/cases/use-cases/build-stage-content.js
+++ b/src/cases/use-cases/build-stage-content.js
@@ -26,7 +26,7 @@ const processStageContentItem = async (item, caseWorkflowContext) => {
   if (!shouldRender) {
     return [];
   }
-  return await resolveContentItem(item, caseWorkflowContext);
+  return resolveContentItem(item, caseWorkflowContext);
 };
 
 const buildContent = async (items, caseWorkflowContext) => {

--- a/src/cases/use-cases/build-stage-content.test.js
+++ b/src/cases/use-cases/build-stage-content.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAfterContent,
+  buildBeforeContent,
+} from "./build-stage-content.js";
+
+const context = { position: { statusCode: "IN_REVIEW" } };
+
+describe("buildBeforeContent", () => {
+  it("returns empty array when stage has no beforeContent", async () => {
+    const result = await buildBeforeContent({}, context);
+    expect(result).toEqual([]);
+  });
+
+  it("includes item when renderIf is truthy", async () => {
+    const stage = {
+      beforeContent: [
+        {
+          renderIf: "jsonata:$.position.statusCode = 'IN_REVIEW'",
+          content: [{ component: "heading", text: "In review", level: 2 }],
+        },
+      ],
+    };
+
+    const result = await buildBeforeContent(stage, context);
+
+    expect(result).toEqual([
+      { component: "heading", text: "In review", level: 2 },
+    ]);
+  });
+
+  it("excludes item when renderIf is falsy", async () => {
+    const stage = {
+      beforeContent: [
+        {
+          renderIf: "jsonata:$.position.statusCode = 'OTHER_STATUS'",
+          content: [
+            { component: "heading", text: "Should not appear", level: 2 },
+          ],
+        },
+      ],
+    };
+
+    const result = await buildBeforeContent(stage, context);
+
+    expect(result).toEqual([]);
+  });
+
+  it("includes item when there is no renderIf", async () => {
+    const stage = {
+      beforeContent: [
+        {
+          content: [{ component: "paragraph", text: "Always visible" }],
+        },
+      ],
+    };
+
+    const result = await buildBeforeContent(stage, context);
+
+    expect(result).toEqual([
+      { component: "paragraph", text: "Always visible" },
+    ]);
+  });
+
+  it("flattens multiple items into a single array", async () => {
+    const stage = {
+      beforeContent: [
+        {
+          renderIf: "jsonata:$.position.statusCode = 'IN_REVIEW'",
+          content: [{ component: "heading", text: "First", level: 2 }],
+        },
+        {
+          renderIf: "jsonata:$.position.statusCode = 'IN_REVIEW'",
+          content: [{ component: "paragraph", text: "Second" }],
+        },
+      ],
+    };
+
+    const result = await buildBeforeContent(stage, context);
+
+    expect(result).toEqual([
+      { component: "heading", text: "First", level: 2 },
+      { component: "paragraph", text: "Second" },
+    ]);
+  });
+});
+
+describe("buildAfterContent", () => {
+  it("returns empty array when stage has no afterContent", async () => {
+    const result = await buildAfterContent({}, context);
+    expect(result).toEqual([]);
+  });
+
+  it("includes item when renderIf is truthy", async () => {
+    const stage = {
+      afterContent: [
+        {
+          renderIf: "jsonata:$.position.statusCode = 'IN_REVIEW'",
+          content: [{ component: "warning-text", text: "Review in progress" }],
+        },
+      ],
+    };
+
+    const result = await buildAfterContent(stage, context);
+
+    expect(result).toEqual([
+      { component: "warning-text", text: "Review in progress" },
+    ]);
+  });
+
+  it("excludes item when renderIf is falsy", async () => {
+    const stage = {
+      afterContent: [
+        {
+          renderIf: "jsonata:$.position.statusCode = 'OTHER_STATUS'",
+          content: [{ component: "warning-text", text: "Should not appear" }],
+        },
+      ],
+    };
+
+    const result = await buildAfterContent(stage, context);
+
+    expect(result).toEqual([]);
+  });
+
+  it("includes item when there is no renderIf", async () => {
+    const stage = {
+      afterContent: [
+        {
+          content: [{ component: "paragraph", text: "Always visible" }],
+        },
+      ],
+    };
+
+    const result = await buildAfterContent(stage, context);
+
+    expect(result).toEqual([
+      { component: "paragraph", text: "Always visible" },
+    ]);
+  });
+
+  it("flattens multiple items into a single array", async () => {
+    const stage = {
+      afterContent: [
+        {
+          renderIf: "jsonata:$.position.statusCode = 'IN_REVIEW'",
+          content: [{ component: "heading", text: "First", level: 2 }],
+        },
+        {
+          renderIf: "jsonata:$.position.statusCode = 'IN_REVIEW'",
+          content: [{ component: "paragraph", text: "Second" }],
+        },
+      ],
+    };
+
+    const result = await buildAfterContent(stage, context);
+
+    expect(result).toEqual([
+      { component: "heading", text: "First", level: 2 },
+      { component: "paragraph", text: "Second" },
+    ]);
+  });
+});

--- a/src/cases/use-cases/create-workflow.use-case.js
+++ b/src/cases/use-cases/create-workflow.use-case.js
@@ -200,6 +200,7 @@ const createWorkflowStage = (stage, context, phases) =>
     ),
     taskGroups: stage.taskGroups.map(createWorkflowTaskGroup),
     beforeContent: stage.beforeContent,
+    afterContent: stage.afterContent,
   });
 
 const createWorkflowPhase = (phase, phases) =>

--- a/src/cases/use-cases/find-case-by-id.use-case.js
+++ b/src/cases/use-cases/find-case-by-id.use-case.js
@@ -12,7 +12,10 @@ import { findAll } from "../../users/repositories/user.repository.js";
 import { EventEnums } from "../models/event-enums.js";
 import { Position } from "../models/position.js";
 import { findById } from "../repositories/case.repository.js";
-import { buildBeforeContent } from "./build-before-content.js";
+import {
+  buildAfterContent,
+  buildBeforeContent,
+} from "./build-stage-content.js";
 import { findWorkflowByCodeUseCase } from "./find-workflow-by-code.use-case.js";
 
 // eslint-disable-next-line complexity
@@ -253,6 +256,11 @@ export const findCaseByIdUseCase = async (caseId, user, request) => {
   const caseStage = kase.getStage();
   const assignedUser = userMap.get(kase.assignedUser?.id);
 
+  const [beforeContent, afterContent] = await Promise.all([
+    buildBeforeContent(workflowStage, caseWorkflowContext),
+    buildAfterContent(workflowStage, caseWorkflowContext),
+  ]);
+
   logger.info(`Finished: Finding case by id "${caseId}"`);
 
   return {
@@ -281,7 +289,8 @@ export const findCaseByIdUseCase = async (caseId, user, request) => {
     links: await buildLinks(caseWorkflowContext),
     comments: mapCommentsWithUsers(kase.comments, userMap),
     timeline: mapTimelineWithUsers(kase.timeline, workflow, userMap),
-    beforeContent: await buildBeforeContent(workflowStage, caseWorkflowContext),
+    beforeContent,
+    afterContent,
   };
 };
 

--- a/src/cases/use-cases/find-case-by-id.use-case.test.js
+++ b/src/cases/use-cases/find-case-by-id.use-case.test.js
@@ -424,6 +424,7 @@ describe("findCaseByIdUseCase", () => {
         },
       ],
       beforeContent: [],
+      afterContent: [],
     });
   });
 
@@ -1656,6 +1657,212 @@ describe("beforeContent", () => {
         component: "heading",
         text: "TEST-REF-123",
         level: 2,
+      },
+    ]);
+  });
+});
+
+describe("afterContent", () => {
+  const authenticatedUserId = new ObjectId().toHexString();
+  const mockAuthUser = User.createMock({
+    id: authenticatedUserId,
+    idpId: new ObjectId().toHexString(),
+    name: "Test User",
+    email: "test.user@example.com",
+    idpRoles: ["user"],
+    appRoles: {},
+  });
+
+  it("returns empty array when stage has no afterContent", async () => {
+    const mockUser = User.createMock();
+    const mockWorkflow = Workflow.createMock();
+    const mockCase = Case.createMock();
+
+    findAll.mockResolvedValue([mockUser]);
+    findWorkflowByCodeUseCase.mockResolvedValue(mockWorkflow);
+    findById.mockResolvedValue(mockCase);
+
+    const result = await findCaseByIdUseCase(mockCase._id, mockAuthUser);
+
+    expect(result.afterContent).toEqual([]);
+  });
+
+  it("processes afterContent with truthy renderIf condition", async () => {
+    const mockUser = User.createMock();
+    const mockWorkflow = Workflow.createMock();
+    const mockCase = Case.createMock();
+
+    const stageWithAfterContent = mockWorkflow.phases[0].stages[0];
+    stageWithAfterContent.afterContent = [
+      {
+        renderIf: "jsonata:$.request.params.tabId = 'task-list'",
+        content: [
+          {
+            component: "warning-text",
+            text: "This is after content",
+          },
+        ],
+      },
+    ];
+
+    findAll.mockResolvedValue([mockUser]);
+    findWorkflowByCodeUseCase.mockResolvedValue(mockWorkflow);
+    findById.mockResolvedValue(mockCase);
+
+    const result = await findCaseByIdUseCase(mockCase._id, mockAuthUser, {
+      params: { tabId: "task-list" },
+    });
+
+    expect(result.afterContent).toEqual([
+      {
+        component: "warning-text",
+        text: "This is after content",
+      },
+    ]);
+  });
+
+  it("filters out afterContent with falsy renderIf condition", async () => {
+    const mockUser = User.createMock();
+    const mockWorkflow = Workflow.createMock();
+    const mockCase = Case.createMock();
+
+    const stageWithAfterContent = mockWorkflow.phases[0].stages[0];
+    stageWithAfterContent.afterContent = [
+      {
+        renderIf: "jsonata:$.request.params.tabId = 'task-list'",
+        content: [
+          {
+            component: "warning-text",
+            text: "This should not appear",
+          },
+        ],
+      },
+    ];
+
+    findAll.mockResolvedValue([mockUser]);
+    findWorkflowByCodeUseCase.mockResolvedValue(mockWorkflow);
+    findById.mockResolvedValue(mockCase);
+
+    const result = await findCaseByIdUseCase(mockCase._id, mockAuthUser, {
+      params: { tabId: "case-details" },
+    });
+
+    expect(result.afterContent).toEqual([]);
+  });
+
+  it("processes multiple afterContent items", async () => {
+    const mockUser = User.createMock();
+    const mockWorkflow = Workflow.createMock();
+    const mockCase = Case.createMock();
+
+    const stageWithAfterContent = mockWorkflow.phases[0].stages[0];
+    stageWithAfterContent.afterContent = [
+      {
+        renderIf: "jsonata:$.request.params.tabId = 'task-list'",
+        content: [
+          {
+            component: "heading",
+            text: "First heading",
+            level: 2,
+          },
+        ],
+      },
+      {
+        renderIf: "jsonata:$.request.params.tabId = 'task-list'",
+        content: [
+          {
+            component: "text",
+            text: "Second text",
+          },
+        ],
+      },
+    ];
+
+    findAll.mockResolvedValue([mockUser]);
+    findWorkflowByCodeUseCase.mockResolvedValue(mockWorkflow);
+    findById.mockResolvedValue(mockCase);
+
+    const result = await findCaseByIdUseCase(mockCase._id, mockAuthUser, {
+      params: { tabId: "task-list" },
+    });
+
+    expect(result.afterContent).toEqual([
+      {
+        component: "heading",
+        text: "First heading",
+        level: 2,
+      },
+      {
+        component: "text",
+        text: "Second text",
+      },
+    ]);
+  });
+
+  it("processes afterContent without renderIf (always included)", async () => {
+    const mockUser = User.createMock();
+    const mockWorkflow = Workflow.createMock();
+    const mockCase = Case.createMock();
+
+    const stageWithAfterContent = mockWorkflow.phases[0].stages[0];
+    stageWithAfterContent.afterContent = [
+      {
+        content: [
+          {
+            component: "paragraph",
+            text: "Always visible content",
+          },
+        ],
+      },
+    ];
+
+    findAll.mockResolvedValue([mockUser]);
+    findWorkflowByCodeUseCase.mockResolvedValue(mockWorkflow);
+    findById.mockResolvedValue(mockCase);
+
+    const result = await findCaseByIdUseCase(mockCase._id, mockAuthUser, {
+      params: { tabId: "any-tab" },
+    });
+
+    expect(result.afterContent).toEqual([
+      {
+        component: "paragraph",
+        text: "Always visible content",
+      },
+    ]);
+  });
+
+  it("resolves JSONPath references in afterContent", async () => {
+    const mockUser = User.createMock();
+    const mockWorkflow = Workflow.createMock();
+    const mockCase = Case.createMock();
+    mockCase.caseRef = "TEST-REF-123";
+
+    const stageWithAfterContent = mockWorkflow.phases[0].stages[0];
+    stageWithAfterContent.afterContent = [
+      {
+        renderIf: "jsonata:$.request.params.tabId = 'task-list'",
+        content: [
+          {
+            component: "paragraph",
+            text: "$.caseRef",
+          },
+        ],
+      },
+    ];
+
+    findAll.mockResolvedValue([mockUser]);
+    findWorkflowByCodeUseCase.mockResolvedValue(mockWorkflow);
+    findById.mockResolvedValue(mockCase);
+
+    const result = await findCaseByIdUseCase(mockCase._id, mockAuthUser, {
+      params: { tabId: "task-list" },
+    });
+
+    expect(result.afterContent).toEqual([
+      {
+        component: "paragraph",
+        text: "TEST-REF-123",
       },
     ]);
   });

--- a/src/common/resolve-json.js
+++ b/src/common/resolve-json.js
@@ -297,7 +297,7 @@ const resolveTemplateComponent = async ({ path, root, row }) => {
     return [];
   }
 
-  return await resolveJSONPath({
+  return resolveJSONPath({
     root,
     path: templateContent,
     row: dataRow,

--- a/test/cases/find-case.test.js
+++ b/test/cases/find-case.test.js
@@ -207,6 +207,7 @@ describe("GET /cases/{caseId}", () => {
         },
       ],
       beforeContent: [],
+      afterContent: [],
       caseSeries: {
         length: 1,
       },

--- a/test/fixtures/workflow.js
+++ b/test/fixtures/workflow.js
@@ -229,6 +229,7 @@ export const workflowData1 = {
           name: "Application Receipt",
           description: "Application received",
           beforeContent: [],
+          afterContent: [],
           statuses: [
             {
               code: "STATUS_1",
@@ -284,6 +285,7 @@ export const workflowData1 = {
           name: "Stage for contract management",
           description: "Awaiting agreement",
           beforeContent: [],
+          afterContent: [],
           statuses: [
             {
               code: "AWAITING_AGREEMENT",
@@ -358,6 +360,7 @@ export const workflowData2 = {
           name: "Review",
           description: "Review description",
           beforeContent: [],
+          afterContent: [],
           statuses: [],
           taskGroups: [],
         },
@@ -366,6 +369,7 @@ export const workflowData2 = {
           name: "Decision",
           description: "Decision description",
           beforeContent: [],
+          afterContent: [],
           statuses: [],
           taskGroups: [],
         },


### PR DESCRIPTION
Removed buildBeforeContent from buildCaseDetailsTabUseCase entirely. 

Stage-level content now only lives on the tasks tab by design, so renderIf conditions only need to check statusCode.

A cleanup migration (20260618120000) strips the now-redundant tabId guards from all woodland and frps workflow documents in the DB.