### PR TITLE
FGP-1182: sync woodland test fixture with second typo fix

### DIFF
--- a/test/fixtures/woodland-workflow-definition.json
+++ b/test/fixtures/woodland-workflow-definition.json
@@ -660,7 +660,7 @@
                 },
                 {
                   "component": "paragraph",
-                  "text": "Select 'Start' to being working on this application."
+                  "text": "Select 'Start' to begin working on this application."
                 }
               ]
             },


### PR DESCRIPTION
The fix-woodland-content-typos migration corrects two strings but the test fixture was only updated for one. Apply the start-screen fix ("being working" -> "begin working") so the fixture matches the migration output.\

https://eaflood.atlassian.net/browse/FGP-1182