### PR TITLE
FGP-787: Remove duplicate empty-state content from workflows

### DIFF
--- a/migrations/20260625120000-remove-duplicate-empty-state-content.js
+++ b/migrations/20260625120000-remove-duplicate-empty-state-content.js
@@ -1,42 +1,52 @@
-const EMPTY_STATE_TEXT = "There are no tasks to complete.";
-
-const isEmptyStateParagraph = (node) =>
-  node !== null &&
-  typeof node === "object" &&
-  node.component === "paragraph" &&
-  node.text === EMPTY_STATE_TEXT;
-
-const removeEmptyStateParagraphs = (node) => {
+const EMPTY_STATE_TEXTS = new Set([
+  "There are no tasks to complete.",
+  "There is nothing more you need to do.",
+  "The agreement has been offered and you don't need to do anything else.",
+]);
+const stageHasTasks = (stage) =>
+  (stage.taskGroups ?? []).some((group) => (group.tasks ?? []).length > 0);
+const removeEmptyStateMessaging = (node) => {
   let changed = false;
-
   if (Array.isArray(node)) {
     for (let i = node.length - 1; i >= 0; i--) {
-      if (isEmptyStateParagraph(node[i])) {
-        node.splice(i, 1);
+      const item = node[i];
+      if (item?.text && EMPTY_STATE_TEXTS.has(item.text)) {
+        if (item.component === "paragraph") {
+          node.splice(i, 1);
+          changed = true;
+          continue;
+        }
+        delete item.text;
         changed = true;
-      } else if (removeEmptyStateParagraphs(node[i])) {
+      }
+      if (removeEmptyStateMessaging(item)) {
         changed = true;
       }
     }
-    return changed;
-  }
-
-  if (node && typeof node === "object") {
-    for (const key of Object.keys(node)) {
-      if (removeEmptyStateParagraphs(node[key])) {
+  } else if (node && typeof node === "object") {
+    for (const value of Object.values(node)) {
+      if (removeEmptyStateMessaging(value)) {
         changed = true;
       }
     }
   }
-
   return changed;
 };
-
 export const up = async (db) => {
   const workflows = await db.collection("workflows").find({}).toArray();
-
   for (const workflow of workflows) {
-    if (removeEmptyStateParagraphs(workflow)) {
+    let changed = false;
+    for (const phase of workflow.phases ?? []) {
+      for (const stage of phase.stages ?? []) {
+        if (
+          !stageHasTasks(stage) &&
+          removeEmptyStateMessaging(stage.beforeContent)
+        ) {
+          changed = true;
+        }
+      }
+    }
+    if (changed) {
       await db
         .collection("workflows")
         .replaceOne({ _id: workflow._id }, workflow);

--- a/migrations/20260625120000-remove-duplicate-empty-state-content.js
+++ b/migrations/20260625120000-remove-duplicate-empty-state-content.js
@@ -1,0 +1,45 @@
+const EMPTY_STATE_TEXT = "There are no tasks to complete.";
+
+const isEmptyStateParagraph = (node) =>
+  node !== null &&
+  typeof node === "object" &&
+  node.component === "paragraph" &&
+  node.text === EMPTY_STATE_TEXT;
+
+const removeEmptyStateParagraphs = (node) => {
+  let changed = false;
+
+  if (Array.isArray(node)) {
+    for (let i = node.length - 1; i >= 0; i--) {
+      if (isEmptyStateParagraph(node[i])) {
+        node.splice(i, 1);
+        changed = true;
+      } else if (removeEmptyStateParagraphs(node[i])) {
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  if (node && typeof node === "object") {
+    for (const key of Object.keys(node)) {
+      if (removeEmptyStateParagraphs(node[key])) {
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+};
+
+export const up = async (db) => {
+  const workflows = await db.collection("workflows").find({}).toArray();
+
+  for (const workflow of workflows) {
+    if (removeEmptyStateParagraphs(workflow)) {
+      await db
+        .collection("workflows")
+        .replaceOne({ _id: workflow._id }, workflow);
+    }
+  }
+};

--- a/test/fixtures/frps-workflow-definition.json
+++ b/test/fixtures/frps-workflow-definition.json
@@ -2199,10 +2199,6 @@
                   "level": 3
                 },
                 {
-                  "component": "paragraph",
-                  "text": "There are no tasks to complete."
-                },
-                {
                   "component": "heading",
                   "text": "You can still withdraw this agreement",
                   "level": 3

--- a/test/fixtures/frps-workflow-definition.json
+++ b/test/fixtures/frps-workflow-definition.json
@@ -2186,7 +2186,6 @@
                   "component": "alert",
                   "variant": "success",
                   "title": "Agreement sent",
-                  "text": "There is nothing more you need to do.",
                   "showTitleAsHeading": true
                 },
                 {

--- a/test/fixtures/woodland-workflow-definition.json
+++ b/test/fixtures/woodland-workflow-definition.json
@@ -801,10 +801,6 @@
               "renderIf": "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_OFFERED'",
               "content": [
                 {
-                  "component": "paragraph",
-                  "text": "The agreement has been offered and you don't need to do anything else."
-                },
-                {
                   "component": "heading",
                   "level": 3,
                   "text": "Withdrawing the agreement"


### PR DESCRIPTION
The caseworking frontend now renders 'There are no tasks to complete.' generically for no-task stages. Remove the same sentence embedded in the FRPS Customer Agreement Review stage beforeContent so it is not rendered twice. Implemented as a generic, idempotent read-modify-write migration over all workflows.


https://eaflood.atlassian.net/browse/FGP-787

Unhappy Path:
<img width="2482" height="1442" alt="image" src="https://github.com/user-attachments/assets/2e142952-fda1-4287-91e5-35e010cb3496" />

Happy Path:
<img width="2482" height="1442" alt="image" src="https://github.com/user-attachments/assets/055aca09-0055-43c9-a6b9-18fad015a562" />
