### PR TITLE
FGP-1076: update our repositories to meet the new defra development standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,23 @@ updates:
       # Include direct package.json updates
       - dependency-type: direct
 
+  # Update Docker base images
+  - package-ecosystem: docker
+    directory: /
+    open-pull-requests-limit: 10
+
+    # Group packages into shared PR
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+
+    # Schedule run every Monday, local time
+    schedule:
+      interval: weekly
+      time: "10:30"
+      timezone: "Europe/London"
+
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Create .env file
+        run: npm run setup:env
+
       - name: Lint
         run: npm run lint
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Create .env file
+        run: npm run setup:env
+
       - name: Lint
         run: npm run lint
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+ignore-scripts=true
+min-release-age=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --no-cache curl
 USER node
 
 COPY --chown=node:node package*.json ./
+COPY --chown=node:node .npmrc ./
 COPY --chown=node:node scripts/run.sh scripts/run.sh
 COPY --chown=node:node scripts/preload.js scripts/preload.js
 COPY --chown=node:node migrate-mongo-config.js ./


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-1076
# FGP-1076: Update fg-cw-backend to meet the new DEFRA development standards

Config-only changes to align with the DEFRA Node.js, Dependabot and dependency-review standards.

## Changes
- `.github/workflows/dependency-review.yml` — new; blocks vulnerable deps on PRs to `main`, actions SHA-pinned.
- `.github/dependabot.yml` — added the `docker` ecosystem (npm + github-actions already present).
- `.npmrc` — added `ignore-scripts=true`, `min-release-age=7` (kept `save-exact=true`).
- `Dockerfile` — copy `.npmrc` before `npm ci --omit=dev` so the image build enforces the same npm security controls.
- `.github/workflows/check-pull-request.yml`, `publish-hotfix.yml` — added a `Create .env file` step (`npm run setup:env`) after `npm ci`.

## Notes
- CI fix explained: `ignore-scripts=true` stops the `postinstall` hook running `setup:env`, so `.env` was no longer created. The integration tests spin up docker compose via testcontainers, and `compose/compose.cw-backend.yml` declares `env_file: .env`, so compose failed with "env file … .env not found" (surfacing as "No test files found"). Adding an explicit `npm run setup:env` step restores it — same fix as fg-gas-backend.
- Local dev: with `ignore-scripts=true`, `npm ci` no longer auto-creates `.env`; run `npm run setup:env` once after install.
- Reviewed (no change): Node v24.14.1 (Active LTS), no TypeScript, ESM, Hapi, npm + lockfile present.
- GHAS - added dependabot security updates and group security updates
