### PR TITLE
FGP-1315 Replace localstack with floci

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ AWS_REGION=eu-west-2
 AWS_DEFAULT_REGION=eu-west-2
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
-AWS_ENDPOINT_URL=http://localstack:4566
+AWS_ENDPOINT_URL=http://floci:4566
 
 CW__SNS__CASE_CREATED_TOPIC_ARN=arn:aws:sns:eu-west-2:000000000000:cw__sns__case_created_fifo.fifo
 CW__SNS__CASE_STATUS_UPDATED_TOPIC_ARN=arn:aws:sns:eu-west-2:000000000000:cw__sns__case_status_updated_fifo.fifo

--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ docker exec -it <container id> sh
 
 ### Useful commands
 
-Docker compose uses localstack to replicate the aws environment.
-Here are some useful commands for interacting with the localstack aws.
+Docker compose uses [floci](https://floci.io) to replicate the aws environment.
+Here are some useful commands for interacting with it. The image ships `awslocal`,
+so these run inside the container: `docker compose exec floci <command>`.
 
 #### List the topics
 
@@ -520,7 +521,7 @@ docker run -e PORT=3001 -p 3001:3001 fg-cw-backend
 
 A local environment with:
 
-- Localstack for AWS services (S3, SQS)
+- floci for AWS services (S3, SQS)
 - MongoDB
 - This service.
 - A commented out frontend example.

--- a/compose.yml
+++ b/compose.yml
@@ -3,20 +3,27 @@ include:
     project_directory: .
 
 services:
-  localstack:
-    image: localstack/localstack:4.3.0
+  floci:
+    image: floci/floci:latest-compat
     ports:
-      - "${LOCALSTACK_PORT:-4566}:4566"
+      - "${FLOCI_PORT:-4566}:4566"
     env_file:
       - "compose/aws.env"
     environment:
-      DEBUG: ${DEBUG:-1}
-      LS_LOG: WARN
-      SERVICES: sqs,sns
-      LOCALSTACK_HOST: 127.0.0.1
+      FLOCI_DEFAULT_REGION: eu-west-2
+      FLOCI_HOSTNAME: 127.0.0.1
     volumes:
-      - ./tmp/localstack:/var/lib/localstack
-      - ./compose/start-localstack.sh:/etc/localstack/init/ready.d/start-localstack.sh
+      - ./compose/floci/start.d:/etc/floci/init/start.d:ro
+    # The image ships a healthcheck, but it only reports that the gateway is
+    # listening - which happens before the init scripts have run. Waiting on the
+    # marker the setup script writes means nothing that depends on floci starts
+    # before its queues and topics exist.
+    healthcheck:
+      test: ["CMD", "stat", "/tmp/READY"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s
     networks:
       - cdp-tenant
 

--- a/compose/compose.cw-backend.yml
+++ b/compose/compose.cw-backend.yml
@@ -3,13 +3,8 @@ services:
     build: .
     ports:
       - "${CW_PORT:-3101}:3101"
-    links:
-      - "localstack:localstack"
-      - "mongo-ready:mongo-ready"
-      - "mongodb:mongodb"
-      - "entra:entra"
     depends_on:
-      localstack:
+      floci:
         condition: service_healthy
       mongo-ready:
         condition: service_healthy

--- a/compose/floci/start.d/10-setup-resources.sh
+++ b/compose/floci/start.d/10-setup-resources.sh
@@ -81,3 +81,6 @@ create_topic_and_queue "gas__sns__create_agreement_fifo.fifo" "create_agreement_
 wait
 
 echo "SNS/SQS ready"
+
+# Marker the compose healthcheck waits on - see the floci service in compose.yml
+echo READY > /tmp/READY

--- a/compose/floci/start.d/10-setup-resources.sh
+++ b/compose/floci/start.d/10-setup-resources.sh
@@ -12,6 +12,15 @@ function create_topic() {
   echo $topic_arn
 }
 
+function create_standard_topic() {
+  local topic_name=$1
+  local topic_arn=$(awslocal sns create-topic \
+	  --name $topic_name \
+	  --query "TopicArn" \
+	  --output text)
+  echo $topic_arn
+}
+
 function create_queue() {
   local queue_name=$1
 
@@ -77,6 +86,10 @@ create_topic_and_queue "gas__sns__application_status_updated_fifo.fifo" "gas__sq
 create_topic_and_queue "gas__sns__create_new_case_fifo.fifo" "cw__sqs__create_new_case_fifo.fifo" &
 create_topic_and_queue "gas__sns__update_case_status_fifo.fifo" "cw__sqs__update_status_fifo.fifo" &
 create_topic_and_queue "gas__sns__create_agreement_fifo.fifo" "create_agreement_fifo.fifo" &
+
+# Standard (non-FIFO) topic the service publishes audit events to. Without it
+# every audit publish fails and the outbox retries it indefinitely.
+create_standard_topic "cw__sns__audit_topic_arn" &
 
 wait
 

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -116,7 +116,7 @@ export const config = convict({
   },
   aws: {
     endpointUrl: {
-      doc: "AWS Endpoint URL used for LocalStack",
+      doc: "AWS Endpoint URL used for floci",
       format: String,
       nullable: true,
       default: null,

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -29,7 +29,6 @@ export const config = convict({
   serviceVersion: {
     doc: "The service version, this variable is injected into your docker container in CDP environments",
     format: String,
-    nullable: true,
     default: null,
     env: "SERVICE_VERSION",
   },

--- a/test/helpers/sns-utils.js
+++ b/test/helpers/sns-utils.js
@@ -2,7 +2,7 @@ import { PublishCommand, SNSClient } from "@aws-sdk/client-sns";
 import { PurgeQueueCommand, SQSClient } from "@aws-sdk/client-sqs";
 import { env } from "node:process";
 
-// Force AWS SDK to use static credentials for LocalStack
+// Force AWS SDK to use static credentials for floci
 const awsConfig = {
   region: env.AWS_REGION || "eu-west-2",
   endpoint: env.AWS_ENDPOINT_URL || "http://localhost:4567",

--- a/test/setup.js
+++ b/test/setup.js
@@ -17,7 +17,7 @@ export const setup = async ({ globalConfig }) => {
     .withEnvironment({
       CW_PORT: env.CW_PORT,
       MONGO_PORT: env.MONGO_PORT,
-      LOCALSTACK_PORT: env.LOCALSTACK_PORT,
+      FLOCI_PORT: env.FLOCI_PORT,
       ENTRA_PORT: env.ENTRA_PORT,
     })
     .withWaitStrategy("fg-cw-backend-1", Wait.forHttp("/health", env.CW_PORT))

--- a/test/vitest.config.js
+++ b/test/vitest.config.js
@@ -2,10 +2,10 @@ import { defineConfig } from "vitest/config";
 
 const CW_PORT = 3101;
 const MONGO_PORT = 27018;
-const LOCALSTACK_PORT = 4567;
+const FLOCI_PORT = 4567;
 const ENTRA_PORT = 3011;
 
-const SQS_URL = `http://sqs.eu-west-2.127.0.0.1:${LOCALSTACK_PORT}/000000000000`;
+const SQS_URL = `http://sqs.eu-west-2.127.0.0.1:${FLOCI_PORT}/000000000000`;
 
 // eslint-disable-next-line import-x/no-default-export
 export default defineConfig({
@@ -21,12 +21,12 @@ export default defineConfig({
     env: {
       CW_PORT,
       MONGO_PORT,
-      LOCALSTACK_PORT,
+      FLOCI_PORT,
       ENTRA_PORT,
       API_URL: `http://localhost:${CW_PORT}`,
       MONGO_URI: `mongodb://localhost:${MONGO_PORT}/fg-cw-backend?directConnection=true`,
       AWS_REGION: "eu-west-2",
-      AWS_ENDPOINT_URL: `http://localhost:${LOCALSTACK_PORT}`,
+      AWS_ENDPOINT_URL: `http://localhost:${FLOCI_PORT}`,
       AWS_ACCESS_KEY_ID: "test",
       AWS_SECRET_ACCESS_KEY: "test",
       CW__SQS__CREATE_NEW_CASE_URL: `${SQS_URL}/cw__sqs__create_new_case_fifo.fifo`,

--- a/test/vitest.config.js
+++ b/test/vitest.config.js
@@ -19,6 +19,7 @@ export default defineConfig({
     fileParallelism: false,
     exclude: ["test/contract/**"],
     env: {
+      SERVICE_VERSION: "0.0.1",
       CW_PORT,
       MONGO_PORT,
       FLOCI_PORT,

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     env: {
+      SERVICE_VERSION: "0.0.1",
       OIDC_JWKS_URI:
         "https://login.microsoftonline.com/common/discovery/v2.0/keys",
       OIDC_VERIFY_ISS: "https://sts.windows.net/common/",


### PR DESCRIPTION
Swaps the local AWS emulator from LocalStack to [floci](https://floci.io), matching `fg-grants-core` (DEFRA/fg-grants-core#27) and the in-flight changes to `fg-gas-backend` (DEFRA/fg-gas-backend#529) and `grants-ui` (DEFRA/grants-ui#1091).

## What changed

- `localstack` service becomes `floci`, on `floci/floci:latest-compat`
- Dropped the `SERVICES` list — floci starts every service, so there's nothing to enumerate
- Init script moves to `compose/floci/start.d/10-setup-resources.sh` and now writes a `/tmp/READY` marker. The image ships a healthcheck, but it only reports that the gateway is listening, which happens *before* the init scripts have run — so the compose healthcheck waits on the marker instead, and nothing starts against an emulator with no queues
- Removed the `links:` block, which is redundant now that every service shares the `cdp-tenant` network
- Dropped the persistent volume — floci is in-memory and resources are recreated on each start
- `LOCALSTACK_PORT` becomes `FLOCI_PORT` in the integration test setup

Plus one fix that surfaced while checking the above: the service publishes audit events to `cw__sns__audit_topic_arn`, but **no init script has ever created it**, so every audit publish failed against a non-existent topic and the outbox retried it forever. The `Updated "1" failed outbox events` lines in CI logs are exactly this. Adding it needed a `create_standard_topic` helper, since the existing `create_topic` only makes FIFO topics. The matching topic for the shared stack is in DEFRA/fg-grants-core#27.

## Verification

Green in CI and locally: **19 test files / 85 tests passed**.

Three timing-sensitive tests that used to flake now pass consistently, since floci starts in milliseconds where LocalStack took seconds.

> If you re-run these locally: the tests join the `cdp-tenant` network, so if `fg-grants-core`'s stack is up it also owns the `mongodb` and `entra` aliases. The tests then resolve to *those* containers and the results are meaningless. Stop that stack first.

## Before you pull

`.env` is gitignored and generated by `setup:env` with `cp --update=none`, so an existing file is **never** refreshed — no matter what changes in `.env.example`. Diff yours against `.env.example` and add anything missing. In particular:

| Variable | Why |
|---|---|
| `AWS_ENDPOINT_URL` | Must become `http://floci:4566`. Otherwise the service fails to start with a DNS error that doesn't obviously point at this. |
| `SERVICE_VERSION` | Now **required** — see below. Without it the service won't start. |
| `CW__SNS__AUDIT_TOPIC_ARN` | Needed to publish audit events to the topic this PR adds. |

All three are already in `.env.example`; the problem is purely that existing files never pick them up. CI is unaffected because `postinstall` regenerates `.env` on a fresh checkout.

### `SERVICE_VERSION` is now required

The audit schema in `@defra/fcp-audit-publisher` marks `version` as `.required()`, and it's populated from `SERVICE_VERSION`. Left nullable, an environment missing that variable built a payload with no version, failed validation, and `writeAuditEvent` logged a WARN and returned normally — **auditing stopped with nothing to indicate it**.

Dropping `nullable: true` makes convict fail at startup instead, naming the setting:

```
serviceVersion: must be of type String
```

CDP injects `SERVICE_VERSION` in deployed environments, so this only surfaces where the value genuinely is absent — and failing to boot is a far better outcome than silently discarding audit events.

Both test configs now set it explicitly. They previously relied on Vite loading `.env`, so the suites depended on an untracked file — a `.env` predating `SERVICE_VERSION` being added to `.env.example` failed 83 unit test files. They're now hermetic.

This narrows one silent failure but not the class of them: `correlationid`, `datetime`, `environment`, `application`, `component` and `ip` are all required too, and `version` is capped at 10 characters, so a long value (a git SHA, a semver with build metadata) would fail the same quiet way. Making `writeAuditEvent` surface validation failures rather than swallow them is the general fix — worth a follow-up ticket.



