### PR TITLE
Propagate floci init script failures

### DIFF
--- a/compose/floci/start.d/10-setup-resources.sh
+++ b/compose/floci/start.d/10-setup-resources.sh
@@ -78,20 +78,34 @@ function create_topic_and_queue() {
 }
 
 
-create_topic_and_queue "cw__sns__case_created_fifo.fifo" "cw__sqs__case_created_fifo.fifo" &
-create_topic_and_queue "cw__sns__case_status_updated_fifo.fifo" "gas__sqs__update_status_fifo.fifo" &
+# Every job is backgrounded to create resources in parallel, and each PID is
+# collected so failures can be waited on individually. A bare `wait` always
+# returns 0 regardless of what the jobs did, so `set -e` would not catch a
+# failed create and this script would exit 0 with resources missing. Floci
+# aborts startup and shuts down when an init script exits non-zero, so
+# propagating the failure turns a silently half-built emulator into a container
+# that refuses to start and says why.
+pids=()
 
-create_topic_and_queue "agreement_status_updated_fifo.fifo" "gas__sqs__update_agreement_status_fifo.fifo" &
-create_topic_and_queue "gas__sns__application_status_updated_fifo.fifo" "gas__sqs__application_status_updated_fifo.fifo" & 
-create_topic_and_queue "gas__sns__create_new_case_fifo.fifo" "cw__sqs__create_new_case_fifo.fifo" &
-create_topic_and_queue "gas__sns__update_case_status_fifo.fifo" "cw__sqs__update_status_fifo.fifo" &
-create_topic_and_queue "gas__sns__create_agreement_fifo.fifo" "create_agreement_fifo.fifo" &
+create_topic_and_queue "cw__sns__case_created_fifo.fifo" "cw__sqs__case_created_fifo.fifo" & pids+=($!)
+create_topic_and_queue "cw__sns__case_status_updated_fifo.fifo" "gas__sqs__update_status_fifo.fifo" & pids+=($!)
+
+create_topic_and_queue "agreement_status_updated_fifo.fifo" "gas__sqs__update_agreement_status_fifo.fifo" & pids+=($!)
+create_topic_and_queue "gas__sns__application_status_updated_fifo.fifo" "gas__sqs__application_status_updated_fifo.fifo" & pids+=($!)
+create_topic_and_queue "gas__sns__create_new_case_fifo.fifo" "cw__sqs__create_new_case_fifo.fifo" & pids+=($!)
+create_topic_and_queue "gas__sns__update_case_status_fifo.fifo" "cw__sqs__update_status_fifo.fifo" & pids+=($!)
+create_topic_and_queue "gas__sns__create_agreement_fifo.fifo" "create_agreement_fifo.fifo" & pids+=($!)
 
 # Standard (non-FIFO) topic the service publishes audit events to. Without it
 # every audit publish fails and the outbox retries it indefinitely.
-create_standard_topic "cw__sns__audit_topic_arn" &
+create_standard_topic "cw__sns__audit_topic_arn" & pids+=($!)
 
-wait
+for pid in "${pids[@]}"; do
+  if ! wait "$pid"; then
+    echo "SNS/SQS setup failed (pid $pid)" >&2
+    exit 1
+  fi
+done
 
 echo "SNS/SQS ready"
 


### PR DESCRIPTION
## What

The floci init script backgrounds every resource-creation job and then calls a bare `wait`. `wait` with no operands always returns `0` regardless of what the jobs did, so `set -e` never caught a failed `create-queue` — the script exited `0` with resources missing, and `/tmp/READY` was written anyway.

This collects each job's PID and waits on them individually, exiting `1` on the first failure. Resource creation still happens in parallel; all jobs are started before any `wait`.

```bash
pids=()
create_topic_and_queue "…" "…" & pids+=($!)
# …
for pid in "${pids[@]}"; do
  if ! wait "$pid"; then
    echo "SNS/SQS setup failed (pid $pid)" >&2
    exit 1
  fi
done
```

## Why it matters

Floci **aborts startup and shuts the emulator down** when an init script exits non-zero:

```
ERROR EmulatorLifecycle  Startup hook execution failed — shutting down:
      IllegalStateException: Hook script failed: 10-setup-resources.sh exited with code 1
INFO  EmulatorLifecycle  === AWS Local Emulator Shutting Down ===
```

So propagating the failure converts a silently half-built emulator — healthy container, missing queues, confusing downstream errors — into a container that refuses to start and says exactly why.

## Verification

**Happy path** — script run in `floci/floci:latest-compat`: container `running`, 0 errors, `SNS/SQS ready` printed, 14 queues (7 sources + 7 FIFO DLQs) and 8 topics created. Unchanged from before.

**Failure path** — seeded a conflicting `gas__sqs__update_status_fifo.fifo` with mismatched attributes ahead of the script so one `create-queue` genuinely fails:

```
CONFLICT-SEEDED
An error occurred (QueueAlreadyExists) when calling the CreateQueue operation:
  A queue already exists with the same name but different attributes.
SNS/SQS setup failed (pid 42)
Hook script failed: 10-setup-resources.sh exited with code 1
=== AWS Local Emulator Shutting Down ===
```

`SNS/SQS ready` never printed, `/tmp/READY` never written, container `exited`. Before this change the same conflict was swallowed and the emulator came up healthy.

## Related

Same fix applied in:

- DEFRA/fg-gas-backend#529 (commit `b90355e`)
- DEFRA/fg-grants-core (`fix/floci-init-failure-propagation`)

All three repos shared this pattern. Worth landing together so the stack behaves consistently.
