### PR TITLE
FGP-961: add POST /users/logout emitting a LOGOUT audit event

### DIFF
--- a/src/common/audit-constants.js
+++ b/src/common/audit-constants.js
@@ -6,6 +6,7 @@ export const auditEntities = {
 
 export const auditActions = {
   LOGIN: "LOGIN",
+  LOGOUT: "LOGOUT",
   CREATE_USER: "CREATE_USER",
   UPDATE_USER: "UPDATE_USER",
   CREATE_ROLE: "CREATE_ROLE",
@@ -21,6 +22,7 @@ export const auditStatus = {
 // Defra Protective Monitoring event reference codes (BUJ QRG v2.2), dashes stripped.
 const pmcCodesByAction = {
   [auditActions.LOGIN]: "0701", // session created
+  [auditActions.LOGOUT]: "0702", // session ended
   [auditActions.CREATE_USER]: "1204", // user registration / service enrollment
   [auditActions.UPDATE_USER]: "0704", // user role change / privilege uplift
   [auditActions.CREATE_ROLE]: "0705", // account permission & privilege management

--- a/src/common/audit-constants.js
+++ b/src/common/audit-constants.js
@@ -22,7 +22,7 @@ export const auditStatus = {
 // Defra Protective Monitoring event reference codes (BUJ QRG v2.2), dashes stripped.
 const pmcCodesByAction = {
   [auditActions.LOGIN]: "0701", // session created
-  [auditActions.LOGOUT]: "0702", // session ended
+  [auditActions.LOGOUT]: "0703", // session ended
   [auditActions.CREATE_USER]: "1204", // user registration / service enrollment
   [auditActions.UPDATE_USER]: "0704", // user role change / privilege uplift
   [auditActions.CREATE_ROLE]: "0705", // account permission & privilege management

--- a/src/users/index.js
+++ b/src/users/index.js
@@ -7,6 +7,7 @@ import { findAssigneesRoute } from "./routes/find-assignees.route.js";
 import { findRoleByCodeRoute } from "./routes/find-role-by-code.route.js";
 import { findRolesRoute } from "./routes/find-roles.route.js";
 import { loginUserRoute } from "./routes/login-user.route.js";
+import { logoutUserRoute } from "./routes/logout-user.route.js";
 import { updateRoleRoute } from "./routes/update-role.route.js";
 import { updateUserRoute } from "./routes/update-user.route.js";
 
@@ -25,6 +26,7 @@ export const users = {
       findRolesRoute,
       findRoleByCodeRoute,
       loginUserRoute,
+      logoutUserRoute,
     ]);
   },
 };

--- a/src/users/routes/logout-user.route.js
+++ b/src/users/routes/logout-user.route.js
@@ -1,0 +1,20 @@
+import { logoutUserRequestSchema } from "../schemas/requests/logout-user-request.schema.js";
+import { logoutUserUseCase } from "../use-cases/logout-user.use-case.js";
+
+const NO_CONTENT_STATUS_CODE = 204;
+
+export const logoutUserRoute = {
+  method: "POST",
+  path: "/users/logout",
+  options: {
+    description: "Record a user logout audit event",
+    tags: ["api"],
+    validate: {
+      payload: logoutUserRequestSchema,
+    },
+  },
+  async handler(request, h) {
+    await logoutUserUseCase(request.payload);
+    return h.response().code(NO_CONTENT_STATUS_CODE);
+  },
+};

--- a/src/users/routes/logout-user.route.test.js
+++ b/src/users/routes/logout-user.route.test.js
@@ -1,0 +1,56 @@
+import hapi from "@hapi/hapi";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { User } from "../models/user.js";
+import { logoutUserUseCase } from "../use-cases/logout-user.use-case.js";
+import { logoutUserRoute } from "./logout-user.route.js";
+
+vi.mock("../use-cases/logout-user.use-case.js");
+
+describe("logoutUserRoute", () => {
+  let server;
+
+  beforeAll(async () => {
+    server = hapi.server();
+    server.route(logoutUserRoute);
+    await server.initialize();
+  });
+
+  afterAll(async () => {
+    await server.stop();
+  });
+
+  it("records the logout and returns 204", async () => {
+    logoutUserUseCase.mockResolvedValue(User.createMock());
+
+    const { statusCode } = await server.inject({
+      method: "POST",
+      url: "/users/logout",
+      payload: { userId: "507f1f77bcf86cd799439011" },
+    });
+
+    expect(statusCode).toEqual(204);
+    expect(logoutUserUseCase).toHaveBeenCalledWith({
+      userId: "507f1f77bcf86cd799439011",
+    });
+  });
+
+  it("returns 400 when userId is missing", async () => {
+    const { statusCode } = await server.inject({
+      method: "POST",
+      url: "/users/logout",
+      payload: {},
+    });
+
+    expect(statusCode).toEqual(400);
+  });
+
+  it("returns 400 when userId is not a valid object id", async () => {
+    const { statusCode } = await server.inject({
+      method: "POST",
+      url: "/users/logout",
+      payload: { userId: "not-an-object-id" },
+    });
+
+    expect(statusCode).toEqual(400);
+  });
+});

--- a/src/users/schemas/requests/logout-user-request.schema.js
+++ b/src/users/schemas/requests/logout-user-request.schema.js
@@ -1,0 +1,13 @@
+import Joi from "joi";
+
+export const logoutUserRequestSchema = Joi.object({
+  userId: Joi.string()
+    .hex()
+    .length(24)
+    .required()
+    .example("507f1f77bcf86cd799439011"),
+})
+  .options({
+    stripUnknown: true,
+  })
+  .label("LogoutUserRequest");

--- a/src/users/use-cases/logout-user.use-case.js
+++ b/src/users/use-cases/logout-user.use-case.js
@@ -1,0 +1,49 @@
+import Boom from "@hapi/boom";
+import {
+  auditActions,
+  auditEntities,
+  buildAuditSecurity,
+} from "../../common/audit-constants.js";
+import { buildSecurityContext } from "../../common/audit-security-context.js";
+import { logger } from "../../common/logger.js";
+import { withAudit } from "../../common/with-audit.js";
+import { findById } from "../repositories/user.repository.js";
+
+const logoutUser = async ({ userId }) => {
+  logger.info(`Processing logout for user with id "${userId}"`);
+
+  const user = await findById(userId);
+
+  if (!user) {
+    throw Boom.notFound(`User with id '${userId}' not found`);
+  }
+
+  logger.info(`Finished: Processing logout for user with id "${userId}"`);
+
+  return user;
+};
+
+export const logoutUserAuditDataBuilder = ([{ userId }], result) => {
+  const idpId = result?.idpId;
+  const details = result
+    ? { security: buildSecurityContext(result) }
+    : { security: { actor: { id: userId } } };
+
+  return {
+    entities: [
+      {
+        entity: auditEntities.USER,
+        action: auditActions.LOGOUT,
+        entityid: idpId,
+      },
+    ],
+    details,
+    security: buildAuditSecurity(auditActions.LOGOUT),
+    messageGroupId: `logout-${idpId ?? userId}`,
+  };
+};
+
+export const logoutUserUseCase = withAudit(
+  logoutUser,
+  logoutUserAuditDataBuilder,
+);

--- a/src/users/use-cases/logout-user.use-case.test.js
+++ b/src/users/use-cases/logout-user.use-case.test.js
@@ -65,7 +65,7 @@ describe("logoutUserUseCase", () => {
             },
           },
         },
-        security: { pmccode: "0702" },
+        security: { pmccode: "0703" },
         messageGroupId: `logout-${mockUser.idpId}`,
         status: auditStatus.SUCCESS,
       }),
@@ -90,7 +90,7 @@ describe("logoutUserUseCase", () => {
           },
         ],
         details: { security: { actor: { id: mockUser.id } } },
-        security: { pmccode: "0702" },
+        security: { pmccode: "0703" },
         status: auditStatus.FAILURE,
       }),
       null,
@@ -139,6 +139,6 @@ describe("logoutUserAuditDataBuilder", () => {
       mockUser,
     );
 
-    expect(auditData.security).toEqual({ pmccode: "0702" });
+    expect(auditData.security).toEqual({ pmccode: "0703" });
   });
 });

--- a/src/users/use-cases/logout-user.use-case.test.js
+++ b/src/users/use-cases/logout-user.use-case.test.js
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { auditStatus } from "../../common/audit-constants.js";
+import { writeAuditEvent } from "../../common/write-audit-event.js";
+import { findById } from "../repositories/user.repository.js";
+import {
+  logoutUserAuditDataBuilder,
+  logoutUserUseCase,
+} from "./logout-user.use-case.js";
+
+vi.mock("../repositories/user.repository.js");
+
+vi.mock("../../common/write-audit-event.js", () => ({
+  writeAuditEvent: vi.fn(),
+}));
+
+const mockUser = {
+  id: "507f1f77bcf86cd799439011",
+  idpId: "6a232710-1c66-4f8b-967d-41d41ae38478",
+  name: "Bob Bill",
+  email: "bob.bill@defra.gov.uk",
+  idpRoles: ["ReadWrite"],
+  appRoles: {},
+};
+
+describe("logoutUserUseCase", () => {
+  beforeEach(() => {
+    writeAuditEvent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the user resolved from the given id", async () => {
+    findById.mockResolvedValue(mockUser);
+
+    const result = await logoutUserUseCase({ userId: mockUser.id });
+
+    expect(findById).toHaveBeenCalledWith(mockUser.id);
+    expect(result).toEqual(mockUser);
+  });
+
+  it("writes a LOGOUT audit event with the actor's security context on success", async () => {
+    findById.mockResolvedValue(mockUser);
+
+    await logoutUserUseCase({ userId: mockUser.id });
+
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entities: [
+          {
+            entity: "USER",
+            action: "LOGOUT",
+            entityid: mockUser.idpId,
+          },
+        ],
+        details: {
+          security: {
+            actor: {
+              id: mockUser.id,
+              idpId: mockUser.idpId,
+              name: mockUser.name,
+              email: mockUser.email,
+              idpRoles: mockUser.idpRoles,
+            },
+          },
+        },
+        security: { pmccode: "0702" },
+        messageGroupId: `logout-${mockUser.idpId}`,
+        status: auditStatus.SUCCESS,
+      }),
+      undefined,
+    );
+  });
+
+  it("throws and writes a FAILURE audit event when the user is not found", async () => {
+    findById.mockResolvedValue(null);
+
+    await expect(logoutUserUseCase({ userId: mockUser.id })).rejects.toThrow(
+      `User with id '${mockUser.id}' not found`,
+    );
+
+    expect(writeAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entities: [
+          {
+            entity: "USER",
+            action: "LOGOUT",
+            entityid: undefined,
+          },
+        ],
+        details: { security: { actor: { id: mockUser.id } } },
+        security: { pmccode: "0702" },
+        status: auditStatus.FAILURE,
+      }),
+      null,
+    );
+  });
+});
+
+describe("logoutUserAuditDataBuilder", () => {
+  it("uses the resolved user as actor and idpId for entityid", () => {
+    const auditData = logoutUserAuditDataBuilder(
+      [{ userId: mockUser.id }],
+      mockUser,
+    );
+
+    expect(auditData.entities[0]).toEqual({
+      entity: "USER",
+      action: "LOGOUT",
+      entityid: mockUser.idpId,
+    });
+    expect(auditData.details.security.actor).toMatchObject({
+      id: mockUser.id,
+      idpId: mockUser.idpId,
+      name: mockUser.name,
+      email: mockUser.email,
+      idpRoles: mockUser.idpRoles,
+    });
+    expect(auditData.messageGroupId).toBe(`logout-${mockUser.idpId}`);
+  });
+
+  it("falls back to the submitted id when there is no result", () => {
+    const auditData = logoutUserAuditDataBuilder(
+      [{ userId: mockUser.id }],
+      undefined,
+    );
+
+    expect(auditData.entities[0].entityid).toBeUndefined();
+    expect(auditData.details).toEqual({
+      security: { actor: { id: mockUser.id } },
+    });
+    expect(auditData.messageGroupId).toBe(`logout-${mockUser.id}`);
+  });
+
+  it("includes a top-level security object for SOC forwarding", () => {
+    const auditData = logoutUserAuditDataBuilder(
+      [{ userId: mockUser.id }],
+      mockUser,
+    );
+
+    expect(auditData.security).toEqual({ pmccode: "0702" });
+  });
+});

--- a/test/users/logout-user.test.js
+++ b/test/users/logout-user.test.js
@@ -63,10 +63,10 @@ describe("POST /users/logout", () => {
   });
 
   it("returns 404 for an unknown user id", async () => {
-    const response = await wreck.post("/users/logout", {
-      payload: { userId: "507f1f77bcf86cd799439011" },
-    });
-
-    expect(response.res.statusCode).toEqual(404);
+    await expect(
+      wreck.post("/users/logout", {
+        payload: { userId: "507f1f77bcf86cd799439011" },
+      }),
+    ).rejects.toThrow("Response Error: 404 Not Found");
   });
 });

--- a/test/users/logout-user.test.js
+++ b/test/users/logout-user.test.js
@@ -1,0 +1,72 @@
+import { MongoClient } from "mongodb";
+import { randomUUID } from "node:crypto";
+import { env } from "node:process";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { wreck } from "../helpers/wreck.js";
+
+let client;
+
+beforeAll(async () => {
+  client = new MongoClient(env.MONGO_URI);
+  await client.connect();
+});
+
+afterAll(async () => {
+  await client.close(true);
+});
+
+describe("POST /users/logout", () => {
+  it("writes a LOGOUT audit event to the outbox for the user", async () => {
+    const idpId = randomUUID();
+
+    const { payload: user } = await wreck.post("/users/login", {
+      payload: {
+        idpId,
+        name: "Logout Test User",
+        email: "logout.test@defra.gov.uk",
+        idpRoles: ["ReadWrite"],
+      },
+    });
+
+    const response = await wreck.post("/users/logout", {
+      payload: { userId: user.id },
+    });
+
+    expect(response.res.statusCode).toEqual(204);
+
+    const outboxEntry = await client.db().collection("outbox").findOne({
+      "event.audit.entities.action": "LOGOUT",
+      "event.audit.entities.entityid": idpId,
+    });
+
+    expect(outboxEntry).toMatchObject({
+      event: {
+        audit: {
+          entities: [{ entity: "USER", action: "LOGOUT", entityid: idpId }],
+          status: "SUCCESS",
+          details: {
+            security: {
+              actor: expect.objectContaining({
+                id: user.id,
+                idpId,
+                name: "Logout Test User",
+                email: "logout.test@defra.gov.uk",
+                idpRoles: ["ReadWrite"],
+              }),
+            },
+          },
+        },
+        security: { pmccode: "0702" },
+      },
+      target: expect.stringMatching(/^arn:aws:sns:eu-west-2:\d+:.*audit.*$/),
+    });
+  });
+
+  it("returns 404 for an unknown user id", async () => {
+    const response = await wreck.post("/users/logout", {
+      payload: { userId: "507f1f77bcf86cd799439011" },
+    });
+
+    expect(response.res.statusCode).toEqual(404);
+  });
+});

--- a/test/users/logout-user.test.js
+++ b/test/users/logout-user.test.js
@@ -56,7 +56,7 @@ describe("POST /users/logout", () => {
             },
           },
         },
-        security: { pmccode: "0702" },
+        security: { pmccode: "0703" },
       },
       target: expect.stringMatching(/^arn:aws:sns:eu-west-2:\d+:.*audit.*$/),
     });


### PR DESCRIPTION
Login already audits LOGIN; this adds the logout audit surface.
[Jira](https://eaflood.atlassian.net/browse/FGP-961)