### PR TITLE
FGP-1268: backfill siti ref on woodlands cases

### DIFF
--- a/compose/seed/woodland/1.0.0/cw/cw.json
+++ b/compose/seed/woodland/1.0.0/cw/cw.json
@@ -1,0 +1,1186 @@
+{
+  "code": "woodland",
+  "requiredRoles": {
+    "allOf": ["ROLE_WMP"],
+    "anyOf": []
+  },
+  "templates": {},
+  "definitions": {
+    "agreementsService": {
+      "internalUrl": "https://fg-cw-frontend.%ENVIRONMENT%.cdp-int.defra.cloud/agreement/{agreementRef}"
+    }
+  },
+  "endpoints": [],
+  "externalActions": [],
+  "pages": {
+    "cases": {
+      "details": {
+        "banner": {
+          "title": {
+            "text": "$.payload.answers.applicant.business.name",
+            "type": "string"
+          },
+          "summary": {
+            "scheme": {
+              "label": "Scheme",
+              "text": "Woodland Management Plan",
+              "type": "string"
+            },
+            "applicationId": {
+              "label": "Application ID",
+              "text": "$.caseRef",
+              "type": "string"
+            },
+            "sbi": {
+              "label": "SBI",
+              "text": "$.payload.identifiers.sbi",
+              "type": "string"
+            },
+            "status": {
+              "label": "Status",
+              "text": "$.currentStatusName",
+              "type": "string"
+            }
+          }
+        },
+        "tabs": {
+          "case-details": {
+            "link": {
+              "id": "case-details",
+              "href": {
+                "urlTemplate": "/cases/{caseId}/case-details",
+                "params": {
+                  "caseId": "$._id"
+                }
+              },
+              "text": "Application",
+              "index": 1
+            },
+            "content": [
+              {
+                "id": "title",
+                "component": "heading",
+                "text": "Application",
+                "level": 2,
+                "classes": "govuk-!-margin-top-6 govuk-!-margin-bottom-1"
+              },
+              {
+                "id": "submittedDate",
+                "component": "container",
+                "classes": "govuk-body",
+                "items": [
+                  {
+                    "text": "Application submitted:",
+                    "classes": "govuk-!-font-weight-regular"
+                  },
+                  {
+                    "text": "$.payload.submittedAt",
+                    "classes": "govuk-!-font-weight-bold",
+                    "format": "formatDate"
+                  }
+                ]
+              },
+              {
+                "component": "accordion",
+                "id": "case-events",
+                "items": [
+                  {
+                    "heading": [
+                      {
+                        "text": "Customer details"
+                      }
+                    ],
+                    "expanded": true,
+                    "content": [
+                      {
+                        "component": "summary-list",
+                        "rows": [
+                          {
+                            "label": "Name",
+                            "text": "$.payload.answers.applicant.customer.name.title $.payload.answers.applicant.customer.name.first $.payload.answers.applicant.customer.name.middle $.payload.answers.applicant.customer.name.last"
+                          },
+                          {
+                            "label": "Business name",
+                            "text": "$.payload.answers.applicant.business.name"
+                          },
+                          {
+                            "label": "Address",
+                            "text": [
+                              {
+                                "component": "text",
+                                "text": "$.payload.answers.applicant.business.address.line1"
+                              },
+                              {
+                                "component": "line-break"
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line2",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line2"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line3",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line3"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line4",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line4"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line5",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line5"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.city",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.city"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "text",
+                                "text": "$.payload.answers.applicant.business.address.postalCode"
+                              }
+                            ]
+                          },
+                          {
+                            "label": "SBI number",
+                            "text": "$.payload.identifiers.sbi"
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.applicant.business.email.address",
+                            "whenTrue": {
+                              "label": "Email address",
+                              "text": "$.payload.answers.applicant.business.email.address"
+                            }
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.applicant.business.phone.landline",
+                            "whenTrue": {
+                              "label": "Telephone",
+                              "text": "$.payload.answers.applicant.business.phone.landline"
+                            }
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.applicant.business.phone.mobile",
+                            "whenTrue": {
+                              "label": "Mobile",
+                              "text": "$.payload.answers.applicant.business.phone.mobile"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Eligibility declarations"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "summary-list",
+                        "rows": [
+                          {
+                            "label": "Business details are up to date",
+                            "text": "$.payload.answers.businessDetailsUpToDate",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Land is registered with RPA",
+                            "text": "$.payload.answers.landRegisteredWithRpa",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Has management control of the land",
+                            "text": "$.payload.answers.landManagementControl",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Public body tenant",
+                            "text": "$.payload.answers.publicBodyTenant",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Land has grazing rights",
+                            "text": "$.payload.answers.landHasGrazingRights",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Guidance read",
+                            "text": "$.payload.answers.guidanceRead",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Application declaration confirmed",
+                            "text": "$.payload.answers.applicationConfirmation",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Existing woodland management plan",
+                            "text": "$.payload.answers.appLandHasExistingWmp",
+                            "format": "yesNo"
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.appLandHasExistingWmp",
+                            "whenTrue": {
+                              "component": "conditional",
+                              "condition": "$.payload.answers.existingWmps",
+                              "whenTrue": {
+                                "label": "Existing woodland management plan details",
+                                "text": "$.payload.answers.existingWmps"
+                              }
+                            }
+                          },
+                          {
+                            "label": "Intends to apply for Higher Tier",
+                            "text": "$.payload.answers.intendToApplyHigherTier",
+                            "format": "yesNo"
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.detailsConfirmedAt",
+                            "whenTrue": {
+                              "label": "Details confirmed",
+                              "text": "$.payload.answers.detailsConfirmedAt",
+                              "format": "formatDateTime"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Woodland details"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "summary-list",
+                        "rows": [
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.woodlandName",
+                            "whenTrue": {
+                              "label": "Woodland name",
+                              "text": "$.payload.answers.woodlandName"
+                            }
+                          },
+                          {
+                            "label": "Total hectares for selected parcels",
+                            "text": "$.payload.answers.totalHectaresForSelectedParcels ha"
+                          },
+                          {
+                            "label": "Woodland 10 years or older",
+                            "text": "$.payload.answers.hectaresTenOrOverYearsOld ha"
+                          },
+                          {
+                            "label": "Woodland under 10 years old",
+                            "text": "$.payload.answers.hectaresUnderTenYearsOld ha"
+                          },
+                          {
+                            "label": "Centre grid reference",
+                            "text": "$.payload.answers.centreGridReference"
+                          },
+                          {
+                            "label": "Forestry commission team code",
+                            "text": "$.payload.answers.fcTeamCode"
+                          },
+                          {
+                            "label": "Included all eligible woodland",
+                            "text": "$.payload.answers.includedAllEligibleWoodland",
+                            "format": "yesNo"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Land parcels"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "table",
+                        "rowsRef": "$.payload.answers.landParcels[*]",
+                        "head": [
+                          {
+                            "component": "text",
+                            "text": "Parcel ID"
+                          },
+                          {
+                            "component": "text",
+                            "text": "Area (ha)",
+                            "format": "fixed(4)"
+                          }
+                        ],
+                        "rows": [
+                          {
+                            "text": "@.parcelId"
+                          },
+                          {
+                            "text": "@.areaHa",
+                            "format": "fixed(4)"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Payment details"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "conditional",
+                        "condition": "$.payload.answers.payments.agreement[0]",
+                        "whenTrue": {
+                          "component": "container",
+                          "items": [
+                            {
+                              "component": "repeat",
+                              "itemsRef": "$.payload.answers.payments.agreement[*]",
+                              "items": [
+                                {
+                                  "component": "heading",
+                                  "text": "@.code",
+                                  "level": 3,
+                                  "classes": "govuk-heading-m govuk-!-margin-bottom-1"
+                                },
+                                {
+                                  "component": "paragraph",
+                                  "text": "@.description",
+                                  "classes": "govuk-body govuk-!-margin-bottom-4"
+                                },
+                                {
+                                  "component": "summary-list",
+                                  "rows": [
+                                    {
+                                      "label": "Active payment tier",
+                                      "text": "@.activePaymentTier"
+                                    },
+                                    {
+                                      "label": "Quantity in active tier",
+                                      "text": "@.quantityInActiveTier @.unit"
+                                    },
+                                    {
+                                      "label": "Active tier rate",
+                                      "text": [
+                                        {
+                                          "text": "@.activeTierRatePence",
+                                          "format": "penniesToPounds"
+                                        },
+                                        {
+                                          "text": " per "
+                                        },
+                                        {
+                                          "text": "@.unit"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "label": "Active tier flat rate",
+                                      "text": "@.activeTierFlatRatePence",
+                                      "format": "penniesToPounds"
+                                    },
+                                    {
+                                      "label": "Total payment",
+                                      "text": "@.agreementTotalPence",
+                                      "format": "penniesToPounds"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "whenFalse": {
+                          "component": "paragraph",
+                          "text": "There are no agreement level actions."
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "component": "paragraph",
+                "text": "Original configuration version $.originalConfigVersion",
+                "classes": "govuk-body"
+              },
+              {
+                "component": "paragraph",
+                "text": "Current configuration version $.currentConfigVersion",
+                "classes": "govuk-body"
+              }
+            ]
+          },
+          "agreements": {
+            "link": {
+              "id": "agreements",
+              "href": {
+                "urlTemplate": "/cases/{caseId}/agreements",
+                "params": {
+                  "caseId": "$._id"
+                }
+              },
+              "text": "Agreements",
+              "index": 2
+            },
+            "renderIf": "$.supplementaryData.agreements[0]",
+            "content": [
+              {
+                "id": "title",
+                "component": "heading",
+                "text": "Funding agreement",
+                "level": 2,
+                "classes": "govuk-!-margin-top-6"
+              },
+              {
+                "component": "summary-list",
+                "rows": [
+                  {
+                    "label": "Agreement status",
+                    "text": [
+                      {
+                        "component": "status",
+                        "text": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].agreementStatus",
+                        "themeMap": {
+                          "AGREEMENT_GENERATING": "INFO",
+                          "AGREEMENT_DRAFTED": "INFO",
+                          "OFFERED": "NOTICE",
+                          "ACCEPTED": "SUCCESS",
+                          "WITHDRAWN": "WARN",
+                          "REJECTED": "ERROR",
+                          "TERMINATED": "ERROR",
+                          "CANCELLED": "WARN"
+                        },
+                        "labelsMap": {
+                          "AGREEMENT_GENERATING": "Agreement generating",
+                          "AGREEMENT_DRAFTED": "Agreement drafted",
+                          "OFFERED": "Offered",
+                          "ACCEPTED": "Accepted",
+                          "WITHDRAWN": "Withdrawn",
+                          "REJECTED": "Rejected",
+                          "TERMINATED": "Terminated",
+                          "CANCELLED": "Cancelled"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "label": "Reference",
+                    "text": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].agreementRef"
+                  },
+                  {
+                    "label": "Date created",
+                    "text": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].createdAt",
+                    "format": "formatDate"
+                  },
+                  {
+                    "label": "Date accepted",
+                    "text": "jsonata:$exists($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(acceptedDate))) ? $fromMillis($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(acceptedDate)), '[D] [MNn,*-3] [Y]') : 'Not accepted'"
+                  },
+                  {
+                    "label": "Start date",
+                    "text": "jsonata:$exists($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(startDate))) ? $fromMillis($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(startDate)), '[D] [MNn,*-3] [Y]') : 'Not started'"
+                  },
+                  {
+                    "label": "End date",
+                    "text": "jsonata:$exists($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(endDate))) ? $fromMillis($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(endDate)), '[D] [MNn,*-3] [Y]') : 'Not started'"
+                  },
+                  {
+                    "label": "View",
+                    "text": [
+                      {
+                        "component": "url",
+                        "text": "View agreement",
+                        "href": {
+                          "urlTemplate": "$.definitions.agreementsService.internalUrl",
+                          "params": {
+                            "agreementRef": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].agreementRef"
+                          }
+                        },
+                        "target": "_blank",
+                        "rel": "noopener"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "phases": [
+    {
+      "code": "PHASE_PRE_AWARD",
+      "name": "Pre-award",
+      "stages": [
+        {
+          "code": "STAGE_REVIEWING_APPLICATION",
+          "name": "Application received",
+          "description": "Review the woodland management plan application",
+          "statuses": [
+            {
+              "code": "STATUS_APPLICATION_RECEIVED",
+              "name": "Application Received",
+              "theme": "NEUTRAL",
+              "description": "Application received and pending review",
+              "interactive": false,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_REVIEWING_APPLICATION:STATUS_APPLICATION_IN_REVIEW",
+                  "checkTasks": false,
+                  "action": {
+                    "code": "ACTION_START_REVIEW",
+                    "name": "Start",
+                    "checkTasks": false,
+                    "comment": null
+                  }
+                }
+              ]
+            },
+            {
+              "code": "STATUS_APPLICATION_IN_REVIEW",
+              "name": "In Review",
+              "theme": "INFO",
+              "description": "Application is being reviewed",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_REVIEWING_APPLICATION:STATUS_AGREEMENT_GENERATING",
+                  "checkTasks": false,
+                  "action": {
+                    "code": "ACTION_APPROVE_APPLICATION",
+                    "name": "Generate agreement",
+                    "checkTasks": false,
+                    "comment": null
+                  }
+                },
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_APPLICATION_AMENDMENT:STATUS_RETURNED_TO_CUSTOMER",
+                  "checkTasks": false,
+                  "action": {
+                    "code": "ACTION_RETURN_TO_CUSTOMER",
+                    "name": "Return to customer",
+                    "checkTasks": false,
+                    "comment": {
+                      "label": {
+                        "text": "Reason for return",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "What is the reason for returning this application to the customer?",
+                      "mandatory": true
+                    },
+                    "confirm": {
+                      "details": [
+                        {
+                          "component": "heading",
+                          "text": "Are you sure you want to return the application to the customer?",
+                          "level": 1,
+                          "classes": "govuk-heading-l"
+                        },
+                        {
+                          "component": "paragraph",
+                          "text": "If you return the application the customer will be able to edit it and then resubmit a new application."
+                        }
+                      ],
+                      "yes": {
+                        "component": "container",
+                        "items": [
+                          {
+                            "component": "text",
+                            "text": "Yes, return the application to customer"
+                          }
+                        ]
+                      },
+                      "no": {
+                        "component": "container",
+                        "items": [
+                          {
+                            "component": "text",
+                            "text": "No, go back to Application received"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "code": "STATUS_AGREEMENT_GENERATING",
+              "name": "Agreement Generating",
+              "theme": "NEUTRAL",
+              "description": "The agreement is being generated",
+              "interactive": false,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_PREPARING_AGREEMENT:STATUS_AGREEMENT_READY_FOR_APPLICANT",
+                  "checkTasks": false,
+                  "action": null
+                }
+              ]
+            }
+          ],
+          "taskGroups": [],
+          "beforeContent": [
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_APPLICATION_IN_REVIEW'",
+              "content": [
+                {
+                  "component": "paragraph",
+                  "text": "Select 'Generate agreement' if you are ready to continue. If the customer needs to make amendments select 'Return to customer'."
+                }
+              ]
+            },
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_APPLICATION_RECEIVED'",
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Reviewing application"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "Select 'Start' to begin working on this application."
+                }
+              ]
+            },
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_GENERATING'",
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Generating draft agreement"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "The draft agreement is being generated and will be available when you refresh the page."
+                },
+                {
+                  "component": "url",
+                  "text": "Refresh page",
+                  "href": {
+                    "urlTemplate": "/cases/{caseId}",
+                    "params": {
+                      "caseId": "$._id"
+                    }
+                  },
+                  "classes": "govuk-button"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Agreement ready for applicant",
+          "code": "STAGE_PREPARING_AGREEMENT",
+          "description": "Send the Agreement to applicant",
+          "statuses": [
+            {
+              "name": "Agreement ready for applicant",
+              "code": "STATUS_AGREEMENT_READY_FOR_APPLICANT",
+              "theme": "NEUTRAL",
+              "description": "The agreement is ready to be sent to the applicant",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_AGREEMENT_WITH_APPLICANT:STATUS_AGREEMENT_OFFERED",
+                  "checkTasks": true,
+                  "action": {
+                    "code": "ACTION_CONFIRM_AGREEMENT_SENT",
+                    "name": "Confirm agreement sent",
+                    "checkTasks": true,
+                    "comment": {
+                      "label": {
+                        "text": "Comment",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "Add comment for auditing purposes.",
+                      "mandatory": false
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "taskGroups": [
+            {
+              "name": "Tasks",
+              "code": "TASK_GROUP_AGREEMENT_PREPARATION",
+              "tasks": [
+                {
+                  "name": "Notify customer that draft agreement is ready",
+                  "code": "TASK_AGREEMENT_DELIVERY_TO_APPLICANT",
+                  "description": [
+                    {
+                      "component": "heading",
+                      "text": "Notify customer that draft agreement is ready",
+                      "level": 2
+                    },
+                    {
+                      "component": "paragraph",
+                      "text": "Send the draft agreement link to the customer or explain why this is not possible."
+                    },
+                    {
+                      "component": "heading",
+                      "text": "Confirm the draft agreement link has been sent",
+                      "level": 3
+                    }
+                  ],
+                  "mandatory": true,
+                  "valueOptions": [
+                    {
+                      "name": "Sent",
+                      "code": "STATUS_AGREEMENT_SENT_TO_APPLICANT",
+                      "theme": "SUCCESS",
+                      "altName": "Sent to customer",
+                      "completes": true,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Enter the CRM reference number to confirm the draft agreement has been sent.",
+                        "mandatory": true
+                      }
+                    },
+                    {
+                      "name": "Not sent",
+                      "code": "STATUS_AGREEMENT_NOT_SENT_TO_APPLICANT",
+                      "theme": "ERROR",
+                      "altName": "Could not send to customer",
+                      "completes": false,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Explain why the draft agreement link could not be sent.",
+                        "mandatory": true
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "beforeContent": [
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_READY_FOR_APPLICANT'",
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Preparing agreement"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "The draft agreement is ready and you need to notify the customer."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Agreement with applicant",
+          "code": "STAGE_AGREEMENT_WITH_APPLICANT",
+          "description": "The id a DESCRIPTION",
+          "beforeContent": [
+            {
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Withdrawing the agreement"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "The agreement can be withdrawn as long as the customer has not already accepted or rejected it."
+                },
+                {
+                  "component": "paragraph",
+                  "text": "You might need to withdraw it if the customer:"
+                },
+                {
+                  "component": "unordered-list",
+                  "items": [
+                    {
+                      "component": "text",
+                      "text": "needs to update their application"
+                    },
+                    {
+                      "component": "text",
+                      "text": "has not responded to the agreement offer within 20 working days"
+                    },
+                    {
+                      "component": "text",
+                      "text": "there is an error in the agreement"
+                    }
+                  ]
+                }
+              ],
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_OFFERED'"
+            }
+          ],
+          "taskGroups": [],
+          "statuses": [
+            {
+              "name": "Agreement offered",
+              "code": "STATUS_AGREEMENT_OFFERED",
+              "theme": "NEUTRAL",
+              "interactive": true,
+              "devComment": "we will have extra transitions below for withdraw and return to customer",
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_AGREEMENT_ACCEPTED:STATUS_AGREEMENT_ACCEPTED",
+                  "checkTasks": false,
+                  "action": null,
+                  "comment": null
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Agreement accepted",
+          "code": "STAGE_AGREEMENT_ACCEPTED",
+          "description": "Forward to Forestry Commission",
+          "statuses": [
+            {
+              "name": "Agreement accepted",
+              "code": "STATUS_AGREEMENT_ACCEPTED",
+              "theme": "NEUTRAL",
+              "description": "Ready to forward to Forestry Commission",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_FC_REVIEWING:STATUS_APPLICATION_AWAITING_FC",
+                  "checkTasks": true,
+                  "action": {
+                    "code": "ACTION_FORWARD_TO_FC",
+                    "name": "Forestry Commission has been notified",
+                    "checkTasks": true,
+                    "comment": {
+                      "label": {
+                        "text": "Comment",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "Add comment for auditing purposes.",
+                      "mandatory": false
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "taskGroups": [
+            {
+              "name": "Tasks",
+              "code": "TASK_GROUP_CRM_RECORD",
+              "tasks": [
+                {
+                  "name": "Create CRM record",
+                  "code": "TASK_CRM_RECORD_CREATION",
+                  "description": [
+                    {
+                      "component": "heading",
+                      "text": "Create CRM record",
+                      "level": 2,
+                      "classes": "govuk-!-margin-bottom-3"
+                    },
+                    {
+                      "component": "paragraph",
+                      "text": "Follow these steps to create the CRM record:"
+                    },
+                    {
+                      "component": "ordered-list",
+                      "items": [
+                        {
+                          "component": "container",
+                          "items": [
+                            {
+                              "component": "text",
+                              "text": "Go to the "
+                            },
+                            {
+                              "component": "url",
+                              "text": "Application tab",
+                              "href": {
+                                "urlTemplate": "/cases/{caseId}/case-details",
+                                "params": {
+                                  "caseId": "$._id"
+                                }
+                              }
+                            },
+                            {
+                              "component": "text",
+                              "text": " to view submitted details."
+                            }
+                          ]
+                        },
+                        {
+                          "component": "text",
+                          "text": "Print or save the application details to a PDF"
+                        },
+                        {
+                          "component": "text",
+                          "text": "Copy the relevant details in to the CRM"
+                        },
+                        {
+                          "component": "text",
+                          "text": "Upload the PDF of the application in to the CRM"
+                        },
+                        {
+                          "component": "text",
+                          "text": "Come back to this page and confirm when the task is complete"
+                        }
+                      ]
+                    },
+                    {
+                      "component": "heading",
+                      "text": "Confirm CRM record has been created",
+                      "level": 3
+                    }
+                  ],
+                  "mandatory": true,
+                  "valueOptions": [
+                    {
+                      "name": "Created",
+                      "code": "STATUS_CRM_RECORD_CREATED",
+                      "theme": "SUCCESS",
+                      "altName": "Created",
+                      "completes": true,
+                      "comment": {
+                        "label": "Enter more information",
+                        "helpText": "You must include an explanation for auditing purposes.",
+                        "mandatory": true
+                      }
+                    },
+                    {
+                      "name": "Not created",
+                      "code": "STATUS_CRM_RECORD_NOT_CREATED",
+                      "theme": "ERROR",
+                      "altName": "Not created",
+                      "completes": false,
+                      "comment": {
+                        "label": "Enter more information",
+                        "helpText": "You must include an explanation for auditing purposes.",
+                        "mandatory": true
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Forestry Commission review",
+          "code": "STAGE_FC_REVIEWING",
+          "description": "Forestry Commission review of the application",
+          "statuses": [
+            {
+              "name": "Awaiting Forestry Commission review",
+              "code": "STATUS_APPLICATION_AWAITING_FC",
+              "theme": "NEUTRAL",
+              "description": "The application has been sent to the Forestry Commission for review",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_APPLICATION_COMPLETED:STATUS_APPLICATION_COMPLETED",
+                  "checkTasks": true,
+                  "action": {
+                    "code": "ACTION_APPROVE_FC_REVIEW",
+                    "name": "Approve Forestry Commission review",
+                    "checkTasks": true,
+                    "comment": {
+                      "label": {
+                        "text": "Comment",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "Add comment for auditing purposes.",
+                      "mandatory": false
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "beforeContent": [
+            {
+              "content": [
+                {
+                  "component": "paragraph",
+                  "text": "The agreement has been offered and you don't need to do anything else."
+                }
+              ],
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_APPLICATION_AWAITING_FC'"
+            }
+          ],
+          "taskGroups": [
+            {
+              "name": "Tasks",
+              "code": "TASK_GROUP_FC_REVIEW",
+              "tasks": [
+                {
+                  "name": "Record Forestry Commission outcome",
+                  "code": "TASK_FC_REVIEW_OUTCOME",
+                  "description": "Record Forestry Commission outcome",
+                  "mandatory": true,
+                  "valueOptions": [
+                    {
+                      "name": "Accepted",
+                      "code": "STATUS_FC_REVIEW_SUCCESSFUL",
+                      "theme": "SUCCESS",
+                      "altName": "Accepted",
+                      "completes": true,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Add comment for auditing purposes.",
+                        "mandatory": true
+                      }
+                    },
+                    {
+                      "name": "Rejected",
+                      "code": "STATUS_FC_REVIEW_UNSUCCESSFUL",
+                      "theme": "ERROR",
+                      "altName": "Rejected",
+                      "completes": false,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Add comment for auditing purposes.",
+                        "mandatory": true
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Application completed",
+          "code": "STAGE_APPLICATION_COMPLETED",
+          "description": "The application is  complete",
+          "statuses": [
+            {
+              "name": "Application completed",
+              "code": "STATUS_APPLICATION_COMPLETED",
+              "theme": "NEUTRAL",
+              "description": "The application is complete",
+              "interactive": false,
+              "transitions": []
+            }
+          ],
+          "taskGroups": []
+        },
+        {
+          "name": "Returned to customer",
+          "code": "STAGE_APPLICATION_AMENDMENT",
+          "description": "The application has been sent back to the client for modification",
+          "statuses": [
+            {
+              "code": "STATUS_RETURNED_TO_CUSTOMER",
+              "name": "Returned to customer",
+              "theme": "WARN",
+              "description": "The application has been sent back to the client for modification",
+              "interactive": false,
+              "closes": true,
+              "transitions": []
+            }
+          ],
+          "taskGroups": [],
+          "beforeContent": [
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_RETURNED_TO_CUSTOMER'",
+              "content": [
+                {
+                  "component": "heading",
+                  "text": "Application returned to customer",
+                  "level": 3
+                },
+                {
+                  "component": "paragraph",
+                  "text": "Application $.caseRef has been returned to customer."
+                },
+                {
+                  "component": "paragraph",
+                  "text": "You need to email the customer to notify them and provide a link to amend their returned application."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "0.0.0"
+}

--- a/compose/seed/woodland/1.0.1/cw/cw.json
+++ b/compose/seed/woodland/1.0.1/cw/cw.json
@@ -1,0 +1,1215 @@
+{
+  "code": "woodland",
+  "requiredRoles": {
+    "allOf": ["ROLE_WMP"],
+    "anyOf": []
+  },
+  "templates": {},
+  "definitions": {
+    "agreementsService": {
+      "internalUrl": "https://fg-cw-frontend.%ENVIRONMENT%.cdp-int.defra.cloud/agreement/{agreementRef}"
+    }
+  },
+  "endpoints": [],
+  "externalActions": [],
+  "pages": {
+    "cases": {
+      "details": {
+        "banner": {
+          "title": {
+            "text": "$.payload.answers.applicant.business.name",
+            "type": "string"
+          },
+          "summary": {
+            "scheme": {
+              "label": "Scheme",
+              "text": "Woodland Management Plan",
+              "type": "string"
+            },
+            "applicationId": {
+              "label": "Application ID",
+              "text": "jsonata:($task := $.phases.stages.taskGroups.tasks[code = 'TASK_SITI_REFERENCE' and completed = true and $trim(value ? value : '') != ''];$exists($task) ? $.caseRef & ' (' & $task.value & ')' : $.caseRef)",
+              "type": "string"
+            },
+            "sbi": {
+              "label": "SBI",
+              "text": "$.payload.identifiers.sbi",
+              "type": "string"
+            },
+            "status": {
+              "label": "Status",
+              "text": "$.currentStatusName",
+              "type": "string"
+            }
+          }
+        },
+        "tabs": {
+          "case-details": {
+            "link": {
+              "id": "case-details",
+              "href": {
+                "urlTemplate": "/cases/{caseId}/case-details",
+                "params": {
+                  "caseId": "$._id"
+                }
+              },
+              "text": "Application",
+              "index": 1
+            },
+            "content": [
+              {
+                "id": "title",
+                "component": "heading",
+                "text": "Application",
+                "level": 2,
+                "classes": "govuk-!-margin-top-6 govuk-!-margin-bottom-1"
+              },
+              {
+                "id": "submittedDate",
+                "component": "container",
+                "classes": "govuk-body",
+                "items": [
+                  {
+                    "text": "Application submitted:",
+                    "classes": "govuk-!-font-weight-regular"
+                  },
+                  {
+                    "text": "$.payload.submittedAt",
+                    "classes": "govuk-!-font-weight-bold",
+                    "format": "formatDate"
+                  }
+                ]
+              },
+              {
+                "component": "accordion",
+                "id": "case-events",
+                "items": [
+                  {
+                    "heading": [
+                      {
+                        "text": "Customer details"
+                      }
+                    ],
+                    "expanded": true,
+                    "content": [
+                      {
+                        "component": "summary-list",
+                        "rows": [
+                          {
+                            "label": "Name",
+                            "text": "$.payload.answers.applicant.customer.name.title $.payload.answers.applicant.customer.name.first $.payload.answers.applicant.customer.name.middle $.payload.answers.applicant.customer.name.last"
+                          },
+                          {
+                            "label": "Business name",
+                            "text": "$.payload.answers.applicant.business.name"
+                          },
+                          {
+                            "label": "Address",
+                            "text": [
+                              {
+                                "component": "text",
+                                "text": "$.payload.answers.applicant.business.address.line1"
+                              },
+                              {
+                                "component": "line-break"
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line2",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line2"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line3",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line3"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line4",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line4"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.line5",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.line5"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "conditional",
+                                "condition": "$.payload.answers.applicant.business.address.city",
+                                "whenTrue": {
+                                  "component": "container",
+                                  "items": [
+                                    {
+                                      "component": "text",
+                                      "text": "$.payload.answers.applicant.business.address.city"
+                                    },
+                                    {
+                                      "component": "line-break"
+                                    }
+                                  ]
+                                }
+                              },
+                              {
+                                "component": "text",
+                                "text": "$.payload.answers.applicant.business.address.postalCode"
+                              }
+                            ]
+                          },
+                          {
+                            "label": "SBI number",
+                            "text": "$.payload.identifiers.sbi"
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.applicant.business.email.address",
+                            "whenTrue": {
+                              "label": "Email address",
+                              "text": "$.payload.answers.applicant.business.email.address"
+                            }
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.applicant.business.phone.landline",
+                            "whenTrue": {
+                              "label": "Telephone",
+                              "text": "$.payload.answers.applicant.business.phone.landline"
+                            }
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.applicant.business.phone.mobile",
+                            "whenTrue": {
+                              "label": "Mobile",
+                              "text": "$.payload.answers.applicant.business.phone.mobile"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Eligibility declarations"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "summary-list",
+                        "rows": [
+                          {
+                            "label": "Business details are up to date",
+                            "text": "$.payload.answers.businessDetailsUpToDate",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Land is registered with RPA",
+                            "text": "$.payload.answers.landRegisteredWithRpa",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Has management control of the land",
+                            "text": "$.payload.answers.landManagementControl",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Public body tenant",
+                            "text": "$.payload.answers.publicBodyTenant",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Land has grazing rights",
+                            "text": "$.payload.answers.landHasGrazingRights",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Guidance read",
+                            "text": "$.payload.answers.guidanceRead",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Application declaration confirmed",
+                            "text": "$.payload.answers.applicationConfirmation",
+                            "format": "yesNo"
+                          },
+                          {
+                            "label": "Existing woodland management plan",
+                            "text": "$.payload.answers.appLandHasExistingWmp",
+                            "format": "yesNo"
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.appLandHasExistingWmp",
+                            "whenTrue": {
+                              "component": "conditional",
+                              "condition": "$.payload.answers.existingWmps",
+                              "whenTrue": {
+                                "label": "Existing woodland management plan details",
+                                "text": "$.payload.answers.existingWmps"
+                              }
+                            }
+                          },
+                          {
+                            "label": "Intends to apply for Higher Tier",
+                            "text": "$.payload.answers.intendToApplyHigherTier",
+                            "format": "yesNo"
+                          },
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.detailsConfirmedAt",
+                            "whenTrue": {
+                              "label": "Details confirmed",
+                              "text": "$.payload.answers.detailsConfirmedAt",
+                              "format": "formatDateTime"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Woodland details"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "summary-list",
+                        "rows": [
+                          {
+                            "component": "conditional",
+                            "condition": "$.payload.answers.woodlandName",
+                            "whenTrue": {
+                              "label": "Woodland name",
+                              "text": "$.payload.answers.woodlandName"
+                            }
+                          },
+                          {
+                            "label": "Total hectares for selected parcels",
+                            "text": "$.payload.answers.totalHectaresForSelectedParcels ha"
+                          },
+                          {
+                            "label": "Woodland 10 years or older",
+                            "text": "$.payload.answers.hectaresTenOrOverYearsOld ha"
+                          },
+                          {
+                            "label": "Woodland under 10 years old",
+                            "text": "$.payload.answers.hectaresUnderTenYearsOld ha"
+                          },
+                          {
+                            "label": "Centre grid reference",
+                            "text": "$.payload.answers.centreGridReference"
+                          },
+                          {
+                            "label": "Forestry commission team code",
+                            "text": "$.payload.answers.fcTeamCode"
+                          },
+                          {
+                            "label": "Included all eligible woodland",
+                            "text": "$.payload.answers.includedAllEligibleWoodland",
+                            "format": "yesNo"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Land parcels"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "table",
+                        "rowsRef": "$.payload.answers.landParcels[*]",
+                        "head": [
+                          {
+                            "component": "text",
+                            "text": "Parcel ID"
+                          },
+                          {
+                            "component": "text",
+                            "text": "Area (ha)",
+                            "format": "fixed(4)"
+                          }
+                        ],
+                        "rows": [
+                          {
+                            "text": "@.parcelId"
+                          },
+                          {
+                            "text": "@.areaHa",
+                            "format": "fixed(4)"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "heading": [
+                      {
+                        "text": "Payment details"
+                      }
+                    ],
+                    "content": [
+                      {
+                        "component": "conditional",
+                        "condition": "$.payload.answers.payments.agreement[0]",
+                        "whenTrue": {
+                          "component": "container",
+                          "items": [
+                            {
+                              "component": "repeat",
+                              "itemsRef": "$.payload.answers.payments.agreement[*]",
+                              "items": [
+                                {
+                                  "component": "heading",
+                                  "text": "@.code",
+                                  "level": 3,
+                                  "classes": "govuk-heading-m govuk-!-margin-bottom-1"
+                                },
+                                {
+                                  "component": "paragraph",
+                                  "text": "@.description",
+                                  "classes": "govuk-body govuk-!-margin-bottom-4"
+                                },
+                                {
+                                  "component": "summary-list",
+                                  "rows": [
+                                    {
+                                      "label": "Active payment tier",
+                                      "text": "@.activePaymentTier"
+                                    },
+                                    {
+                                      "label": "Quantity in active tier",
+                                      "text": "@.quantityInActiveTier @.unit"
+                                    },
+                                    {
+                                      "label": "Active tier rate",
+                                      "text": [
+                                        {
+                                          "text": "@.activeTierRatePence",
+                                          "format": "penniesToPounds"
+                                        },
+                                        {
+                                          "text": " per "
+                                        },
+                                        {
+                                          "text": "@.unit"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "label": "Active tier flat rate",
+                                      "text": "@.activeTierFlatRatePence",
+                                      "format": "penniesToPounds"
+                                    },
+                                    {
+                                      "label": "Total payment",
+                                      "text": "@.agreementTotalPence",
+                                      "format": "penniesToPounds"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "whenFalse": {
+                          "component": "paragraph",
+                          "text": "There are no agreement level actions."
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "component": "paragraph",
+                "text": "Original configuration version $.originalConfigVersion",
+                "classes": "govuk-body"
+              },
+              {
+                "component": "paragraph",
+                "text": "Current configuration version $.currentConfigVersion",
+                "classes": "govuk-body"
+              }
+            ]
+          },
+          "agreements": {
+            "link": {
+              "id": "agreements",
+              "href": {
+                "urlTemplate": "/cases/{caseId}/agreements",
+                "params": {
+                  "caseId": "$._id"
+                }
+              },
+              "text": "Agreements",
+              "index": 2
+            },
+            "renderIf": "$.supplementaryData.agreements[0]",
+            "content": [
+              {
+                "id": "title",
+                "component": "heading",
+                "text": "Funding agreement",
+                "level": 2,
+                "classes": "govuk-!-margin-top-6"
+              },
+              {
+                "component": "summary-list",
+                "rows": [
+                  {
+                    "label": "Agreement status",
+                    "text": [
+                      {
+                        "component": "status",
+                        "text": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].agreementStatus",
+                        "themeMap": {
+                          "AGREEMENT_GENERATING": "INFO",
+                          "AGREEMENT_DRAFTED": "INFO",
+                          "OFFERED": "NOTICE",
+                          "ACCEPTED": "SUCCESS",
+                          "WITHDRAWN": "WARN",
+                          "REJECTED": "ERROR",
+                          "TERMINATED": "ERROR",
+                          "CANCELLED": "WARN"
+                        },
+                        "labelsMap": {
+                          "AGREEMENT_GENERATING": "Agreement generating",
+                          "AGREEMENT_DRAFTED": "Agreement drafted",
+                          "OFFERED": "Offered",
+                          "ACCEPTED": "Accepted",
+                          "WITHDRAWN": "Withdrawn",
+                          "REJECTED": "Rejected",
+                          "TERMINATED": "Terminated",
+                          "CANCELLED": "Cancelled"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "label": "Reference",
+                    "text": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].agreementRef"
+                  },
+                  {
+                    "label": "Date created",
+                    "text": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].createdAt",
+                    "format": "formatDate"
+                  },
+                  {
+                    "label": "Date accepted",
+                    "text": "jsonata:$exists($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(acceptedDate))) ? $fromMillis($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(acceptedDate)), '[D] [MNn,*-3] [Y]') : 'Not accepted'"
+                  },
+                  {
+                    "label": "Start date",
+                    "text": "jsonata:$exists($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(startDate))) ? $fromMillis($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(startDate)), '[D] [MNn,*-3] [Y]') : 'Not started'"
+                  },
+                  {
+                    "label": "End date",
+                    "text": "jsonata:$exists($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(endDate))) ? $fromMillis($max($.supplementaryData.agreements[agreementStatus='ACCEPTED'].$toMillis(endDate)), '[D] [MNn,*-3] [Y]') : 'Not started'"
+                  },
+                  {
+                    "label": "View",
+                    "text": [
+                      {
+                        "component": "url",
+                        "text": "View agreement",
+                        "href": {
+                          "urlTemplate": "$.definitions.agreementsService.internalUrl",
+                          "params": {
+                            "agreementRef": "jsonata:$sort($.supplementaryData.agreements, function($l, $r) { $l.createdAt < $r.createdAt })[0].agreementRef"
+                          }
+                        },
+                        "target": "_blank",
+                        "rel": "noopener"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "phases": [
+    {
+      "code": "PHASE_PRE_AWARD",
+      "name": "Pre-award",
+      "stages": [
+        {
+          "code": "STAGE_REVIEWING_APPLICATION",
+          "name": "Application received",
+          "description": "Review the woodland management plan application",
+          "statuses": [
+            {
+              "code": "STATUS_APPLICATION_RECEIVED",
+              "name": "Application Received",
+              "theme": "NEUTRAL",
+              "description": "Application received and pending review",
+              "interactive": false,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_REVIEWING_APPLICATION:STATUS_APPLICATION_IN_REVIEW",
+                  "checkTasks": false,
+                  "action": {
+                    "code": "ACTION_START_REVIEW",
+                    "name": "Start",
+                    "checkTasks": false,
+                    "comment": null
+                  }
+                }
+              ]
+            },
+            {
+              "code": "STATUS_APPLICATION_IN_REVIEW",
+              "name": "In Review",
+              "theme": "INFO",
+              "description": "Application is being reviewed",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_REVIEWING_APPLICATION:STATUS_AGREEMENT_GENERATING",
+                  "checkTasks": false,
+                  "action": {
+                    "code": "ACTION_APPROVE_APPLICATION",
+                    "name": "Generate agreement",
+                    "checkTasks": false,
+                    "comment": null
+                  }
+                },
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_APPLICATION_AMENDMENT:STATUS_RETURNED_TO_CUSTOMER",
+                  "checkTasks": false,
+                  "action": {
+                    "code": "ACTION_RETURN_TO_CUSTOMER",
+                    "name": "Return to customer",
+                    "checkTasks": false,
+                    "comment": {
+                      "label": {
+                        "text": "Reason for return",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "What is the reason for returning this application to the customer?",
+                      "mandatory": true
+                    },
+                    "confirm": {
+                      "details": [
+                        {
+                          "component": "heading",
+                          "text": "Are you sure you want to return the application to the customer?",
+                          "level": 1,
+                          "classes": "govuk-heading-l"
+                        },
+                        {
+                          "component": "paragraph",
+                          "text": "If you return the application the customer will be able to edit it and then resubmit a new application."
+                        }
+                      ],
+                      "yes": {
+                        "component": "container",
+                        "items": [
+                          {
+                            "component": "text",
+                            "text": "Yes, return the application to customer"
+                          }
+                        ]
+                      },
+                      "no": {
+                        "component": "container",
+                        "items": [
+                          {
+                            "component": "text",
+                            "text": "No, go back to Application received"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "code": "STATUS_AGREEMENT_GENERATING",
+              "name": "Agreement Generating",
+              "theme": "NEUTRAL",
+              "description": "The agreement is being generated",
+              "interactive": false,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_PREPARING_AGREEMENT:STATUS_AGREEMENT_READY_FOR_APPLICANT",
+                  "checkTasks": false,
+                  "action": null
+                }
+              ]
+            }
+          ],
+          "taskGroups": [],
+          "beforeContent": [
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_APPLICATION_IN_REVIEW'",
+              "content": [
+                {
+                  "component": "paragraph",
+                  "text": "Select 'Generate agreement' if you are ready to continue. If the customer needs to make amendments select 'Return to customer'."
+                }
+              ]
+            },
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_APPLICATION_RECEIVED'",
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Reviewing application"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "Select 'Start' to begin working on this application."
+                }
+              ]
+            },
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_GENERATING'",
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Generating draft agreement"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "The draft agreement is being generated and will be available when you refresh the page."
+                },
+                {
+                  "component": "url",
+                  "text": "Refresh page",
+                  "href": {
+                    "urlTemplate": "/cases/{caseId}",
+                    "params": {
+                      "caseId": "$._id"
+                    }
+                  },
+                  "classes": "govuk-button"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Agreement ready for applicant",
+          "code": "STAGE_PREPARING_AGREEMENT",
+          "description": "Send the Agreement to applicant",
+          "statuses": [
+            {
+              "name": "Agreement ready for applicant",
+              "code": "STATUS_AGREEMENT_READY_FOR_APPLICANT",
+              "theme": "NEUTRAL",
+              "description": "The agreement is ready to be sent to the applicant",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_AGREEMENT_WITH_APPLICANT:STATUS_AGREEMENT_OFFERED",
+                  "checkTasks": true,
+                  "action": {
+                    "code": "ACTION_CONFIRM_AGREEMENT_SENT",
+                    "name": "Confirm agreement sent",
+                    "checkTasks": true,
+                    "comment": {
+                      "label": {
+                        "text": "Comment",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "Add comment for auditing purposes.",
+                      "mandatory": false
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "taskGroups": [
+            {
+              "name": "Tasks",
+              "code": "TASK_GROUP_AGREEMENT_PREPARATION",
+              "tasks": [
+                {
+                  "name": "Notify customer that draft agreement is ready",
+                  "code": "TASK_AGREEMENT_DELIVERY_TO_APPLICANT",
+                  "description": [
+                    {
+                      "component": "heading",
+                      "text": "Notify customer that draft agreement is ready",
+                      "level": 2
+                    },
+                    {
+                      "component": "paragraph",
+                      "text": "Send the draft agreement link to the customer or explain why this is not possible."
+                    },
+                    {
+                      "component": "heading",
+                      "text": "Confirm the draft agreement link has been sent",
+                      "level": 3
+                    }
+                  ],
+                  "mandatory": true,
+                  "valueOptions": [
+                    {
+                      "name": "Sent",
+                      "code": "STATUS_AGREEMENT_SENT_TO_APPLICANT",
+                      "theme": "SUCCESS",
+                      "altName": "Sent to customer",
+                      "completes": true,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Enter the CRM reference number to confirm the draft agreement has been sent.",
+                        "mandatory": true
+                      }
+                    },
+                    {
+                      "name": "Not sent",
+                      "code": "STATUS_AGREEMENT_NOT_SENT_TO_APPLICANT",
+                      "theme": "ERROR",
+                      "altName": "Could not send to customer",
+                      "completes": false,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Explain why the draft agreement link could not be sent.",
+                        "mandatory": true
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "beforeContent": [
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_READY_FOR_APPLICANT'",
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Preparing agreement"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "The draft agreement is ready and you need to notify the customer."
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Agreement with applicant",
+          "code": "STAGE_AGREEMENT_WITH_APPLICANT",
+          "description": "The id a DESCRIPTION",
+          "beforeContent": [
+            {
+              "content": [
+                {
+                  "component": "heading",
+                  "level": 3,
+                  "text": "Withdrawing the agreement"
+                },
+                {
+                  "component": "paragraph",
+                  "text": "The agreement can be withdrawn as long as the customer has not already accepted or rejected it."
+                },
+                {
+                  "component": "paragraph",
+                  "text": "You might need to withdraw it if the customer:"
+                },
+                {
+                  "component": "unordered-list",
+                  "items": [
+                    {
+                      "component": "text",
+                      "text": "needs to update their application"
+                    },
+                    {
+                      "component": "text",
+                      "text": "has not responded to the agreement offer within 20 working days"
+                    },
+                    {
+                      "component": "text",
+                      "text": "there is an error in the agreement"
+                    }
+                  ]
+                }
+              ],
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_AGREEMENT_OFFERED'"
+            }
+          ],
+          "taskGroups": [],
+          "statuses": [
+            {
+              "name": "Agreement offered",
+              "code": "STATUS_AGREEMENT_OFFERED",
+              "theme": "NEUTRAL",
+              "interactive": true,
+              "devComment": "we will have extra transitions below for withdraw and return to customer",
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_AGREEMENT_ACCEPTED:STATUS_AGREEMENT_ACCEPTED",
+                  "checkTasks": false,
+                  "action": null,
+                  "comment": null
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Agreement accepted",
+          "code": "STAGE_AGREEMENT_ACCEPTED",
+          "description": "Forward to Forestry Commission",
+          "statuses": [
+            {
+              "name": "Agreement accepted",
+              "code": "STATUS_AGREEMENT_ACCEPTED",
+              "theme": "NEUTRAL",
+              "description": "Ready to forward to Forestry Commission",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_FC_REVIEWING:STATUS_APPLICATION_AWAITING_FC",
+                  "checkTasks": true,
+                  "action": {
+                    "code": "ACTION_FORWARD_TO_FC",
+                    "name": "Forestry Commission has been notified",
+                    "checkTasks": true,
+                    "comment": {
+                      "label": {
+                        "text": "Comment",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "Add comment for auditing purposes.",
+                      "mandatory": false
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "taskGroups": [
+            {
+              "name": "Tasks",
+              "code": "TASK_GROUP_CRM_RECORD",
+              "tasks": [
+                {
+                  "code": "TASK_SITI_REFERENCE",
+                  "name": "Add SitiAgri Reference",
+                  "mandatory": true,
+                  "description": [
+                    {
+                      "component": "heading",
+                      "text": "Add SitiAgri reference",
+                      "level": 2,
+                      "classes": "govuk-heading-l"
+                    },
+                    {
+                      "component": "paragraph",
+                      "text": "You need to add the SitiAgri reference before you can assign an application to the Forestry Commission. You can find this reference by searching the SBI of the business on the MI toolkit."
+                    }
+                  ],
+                  "input": {
+                    "type": "text",
+                    "label": {
+                      "text": "Enter SitiAgri reference",
+                      "classes": "govuk-label--m"
+                    },
+                    "pattern": "^[0-9]{7}$",
+                    "maxlength": 7,
+                    "hint": [
+                      "Provide the 7 digit SitiAgri reference for the Forestry Commission"
+                    ]
+                  }
+                },
+                {
+                  "name": "Create CRM record",
+                  "code": "TASK_CRM_RECORD_CREATION",
+                  "description": [
+                    {
+                      "component": "heading",
+                      "text": "Create CRM record",
+                      "level": 2,
+                      "classes": "govuk-!-margin-bottom-3"
+                    },
+                    {
+                      "component": "paragraph",
+                      "text": "Follow these steps to create the CRM record:"
+                    },
+                    {
+                      "component": "ordered-list",
+                      "items": [
+                        {
+                          "component": "container",
+                          "items": [
+                            {
+                              "component": "text",
+                              "text": "Go to the "
+                            },
+                            {
+                              "component": "url",
+                              "text": "Application tab",
+                              "href": {
+                                "urlTemplate": "/cases/{caseId}/case-details",
+                                "params": {
+                                  "caseId": "$._id"
+                                }
+                              }
+                            },
+                            {
+                              "component": "text",
+                              "text": " to view submitted details."
+                            }
+                          ]
+                        },
+                        {
+                          "component": "text",
+                          "text": "Print or save the application details to a PDF"
+                        },
+                        {
+                          "component": "text",
+                          "text": "Copy the relevant details in to the CRM"
+                        },
+                        {
+                          "component": "text",
+                          "text": "Upload the PDF of the application in to the CRM"
+                        },
+                        {
+                          "component": "text",
+                          "text": "Come back to this page and confirm when the task is complete"
+                        }
+                      ]
+                    },
+                    {
+                      "component": "heading",
+                      "text": "Confirm CRM record has been created",
+                      "level": 3
+                    }
+                  ],
+                  "mandatory": true,
+                  "valueOptions": [
+                    {
+                      "name": "Created",
+                      "code": "STATUS_CRM_RECORD_CREATED",
+                      "theme": "SUCCESS",
+                      "altName": "Created",
+                      "completes": true,
+                      "comment": {
+                        "label": "Enter more information",
+                        "helpText": "You must include an explanation for auditing purposes.",
+                        "mandatory": true
+                      }
+                    },
+                    {
+                      "name": "Not created",
+                      "code": "STATUS_CRM_RECORD_NOT_CREATED",
+                      "theme": "ERROR",
+                      "altName": "Not created",
+                      "completes": false,
+                      "comment": {
+                        "label": "Enter more information",
+                        "helpText": "You must include an explanation for auditing purposes.",
+                        "mandatory": true
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Forestry Commission review",
+          "code": "STAGE_FC_REVIEWING",
+          "description": "Forestry Commission review of the application",
+          "statuses": [
+            {
+              "name": "Awaiting Forestry Commission review",
+              "code": "STATUS_APPLICATION_AWAITING_FC",
+              "theme": "NEUTRAL",
+              "description": "The application has been sent to the Forestry Commission for review",
+              "interactive": true,
+              "transitions": [
+                {
+                  "targetPosition": "PHASE_PRE_AWARD:STAGE_APPLICATION_COMPLETED:STATUS_APPLICATION_COMPLETED",
+                  "checkTasks": true,
+                  "action": {
+                    "code": "ACTION_APPROVE_FC_REVIEW",
+                    "name": "Approve Forestry Commission review",
+                    "checkTasks": true,
+                    "comment": {
+                      "label": {
+                        "text": "Comment",
+                        "classes": "govuk-visually-hidden"
+                      },
+                      "helpText": "Add comment for auditing purposes.",
+                      "mandatory": false
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "beforeContent": [
+            {
+              "content": [
+                {
+                  "component": "paragraph",
+                  "text": "The agreement has been offered and you don't need to do anything else."
+                }
+              ],
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_APPLICATION_AWAITING_FC'"
+            }
+          ],
+          "taskGroups": [
+            {
+              "name": "Tasks",
+              "code": "TASK_GROUP_FC_REVIEW",
+              "tasks": [
+                {
+                  "name": "Record Forestry Commission outcome",
+                  "code": "TASK_FC_REVIEW_OUTCOME",
+                  "description": "Record Forestry Commission outcome",
+                  "mandatory": true,
+                  "valueOptions": [
+                    {
+                      "name": "Accepted",
+                      "code": "STATUS_FC_REVIEW_SUCCESSFUL",
+                      "theme": "SUCCESS",
+                      "altName": "Accepted",
+                      "completes": true,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Add comment for auditing purposes.",
+                        "mandatory": true
+                      }
+                    },
+                    {
+                      "name": "Rejected",
+                      "code": "STATUS_FC_REVIEW_UNSUCCESSFUL",
+                      "theme": "ERROR",
+                      "altName": "Rejected",
+                      "completes": false,
+                      "comment": {
+                        "label": "Explanation",
+                        "helpText": "Add comment for auditing purposes.",
+                        "mandatory": true
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Application completed",
+          "code": "STAGE_APPLICATION_COMPLETED",
+          "description": "The application is  complete",
+          "statuses": [
+            {
+              "name": "Application completed",
+              "code": "STATUS_APPLICATION_COMPLETED",
+              "theme": "NEUTRAL",
+              "description": "The application is complete",
+              "interactive": false,
+              "transitions": []
+            }
+          ],
+          "taskGroups": []
+        },
+        {
+          "name": "Returned to customer",
+          "code": "STAGE_APPLICATION_AMENDMENT",
+          "description": "The application has been sent back to the client for modification",
+          "statuses": [
+            {
+              "code": "STATUS_RETURNED_TO_CUSTOMER",
+              "name": "Returned to customer",
+              "theme": "WARN",
+              "description": "The application has been sent back to the client for modification",
+              "interactive": false,
+              "closes": true,
+              "transitions": []
+            }
+          ],
+          "taskGroups": [],
+          "beforeContent": [
+            {
+              "renderIf": "jsonata:$.position.statusCode = 'STATUS_RETURNED_TO_CUSTOMER'",
+              "content": [
+                {
+                  "component": "heading",
+                  "text": "Application returned to customer",
+                  "level": 3
+                },
+                {
+                  "component": "paragraph",
+                  "text": "Application $.caseRef has been returned to customer."
+                },
+                {
+                  "component": "paragraph",
+                  "text": "You need to email the customer to notify them and provide a link to amend their returned application."
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "version": "0.0.0"
+}

--- a/migrations/20260806101443-wmp-add-siti-agri-ref.js
+++ b/migrations/20260806101443-wmp-add-siti-agri-ref.js
@@ -5,12 +5,12 @@ export const up = async (db) => {
     "wood-1001": 1010101,
 
     // develop
-    "wmp-967-b2u": 2222222,
+    "wmp-967-b2u": 2222222, // is accepted
 
     // test
-    "wmp-zum-ypr": 3333333,
+    "wmp-zum-ypr": 3333333, // is accepted
 
-    //
+    // prod
     "wmp-l8r-329": 2326337,
     "wmp-rku-ha4": 2348574,
     "wmp-ylw-4jl": 2305310,
@@ -48,6 +48,30 @@ export const up = async (db) => {
     "wmp-awp-bkp": 2291951,
     "wmp-3zp-hwl": 2318913,
     "wmp-8cv-768": 2341576,
+    "wmp-hlr-abn": 2296339,
+    "wmp-zjh-3jl": 2340794,
+    "wmp-nf4-bn5": 2264699,
+    "wmp-228-kra": 2336940,
+    "wmp-b4j-7s2": 2453823,
+    "wmp-lp8-tvx": 2348726,
+    "wmp-4xs-twt": 2345445,
+    "wmp-rnr-res": 2346201,
+    "wmp-p8n-c2c": 2335973,
+    "wmp-vss-tae": 2344996,
+    "wmp-pl4-pdc": 2343986,
+    "wmp-uc4-u9s": 2343947,
+    "wmp-dr5-tzd": 2449146,
+    "wmp-867-s22": 2331858,
+    "wmp-py3-wx8": 2344231,
+    "wmp-tfz-lnc": 2453465,
+    "wmp-792-68t": 2346889,
+    "wmp-c4j-y3y": 2453062,
+    "wmp-fz7-5a4": 2348615,
+    "wmp-m85-kbw": 2453453,
+    "wmp-m8p-v78": 2340798,
+    "wmp-fu9-nbv": 2348106,
+    "wmp-2tu-tua": 2345972,
+    "wmp-uxa-6kn": 2458804,
   };
 
   const task = {

--- a/migrations/20260806101443-wmp-add-siti-agri-ref.js
+++ b/migrations/20260806101443-wmp-add-siti-agri-ref.js
@@ -1,44 +1,53 @@
 import { withTransaction } from "../src/common/with-transaction.js";
 
-export const up = async (db, client) => {
+export const up = async (db) => {
   const refs = {
-    106241643: "2326337",
-    106323196: "2348574",
-    106490576: "2305310",
-    106553297: "2342972",
-    106634181: "2337697",
-    106668514: "2338801",
-    106692400: "2338146",
-    106776150: "2298162",
-    106933321: "2295123",
-    106969836: "2341558",
-    107006764: "2320439",
-    107059405: "2339149",
-    107082687: "2314222",
-    107124756: "2286716",
-    107138876: "2315984",
-    110192152: "2338513",
-    110327815: "2332924",
-    110545261: "2337012",
-    114352085: "2342146",
-    116623145: "2323988",
-    117570918: "2265948",
-    117571851: "2265872",
-    122259669: "2337691",
-    200008255: "2337285",
-    200105772: "2328369",
-    200628182: "2334316",
-    200922657: "2342831",
-    200927219: "2286938",
-    201109197: "2244737",
-    201115195: "2338603",
-    201117357: "2263459",
-    201127086: "2283622",
-    201127543: "2286784",
-    201128065: "2297777",
-    201130003: "2291951",
-    201141756: "2318913",
-    201145088: "2341576",
+    "wood-1001": 1010101,
+
+    // develop
+    "wmp-967-b2u": 2222222,
+
+    // test
+    "wmp-zum-ypr": 3333333,
+
+    //
+    "wmp-l8r-329": 2326337,
+    "wmp-rku-ha4": 2348574,
+    "wmp-ylw-4jl": 2305310,
+    "wmp-vt8-j4a": 2342972,
+    "wmp-x7m-l38": 2337697,
+    "wmp-2ax-726": 2338801,
+    "wmp-5f4-jza": 2338146,
+    "wmp-ns8-j3x": 2298162,
+    "wmp-js2-u7c": 2295123,
+    "wmp-4u7-dm3": 2341558,
+    "wmp-yjd-ww3": 2320439,
+    "wmp-sh3-d4k": 2339149,
+    "wmp-9kn-87r": 2314222,
+    "wmp-lam-zvk": 2286716,
+    "wmp-5kb-wav": 2315984,
+    "wmp-fuh-rwr": 2338513,
+    "wmp-sat-n6h": 2332924,
+    "wmp-ve5-bxu": 2337012,
+    "wmp-tc3-ac8": 2342146,
+    "wmp-24b-wyn": 2323988,
+    "wmp-mrl-b74": 2265948,
+    "wmp-vwd-bhm": 2265872,
+    "wmp-nvk-v6v": 2337691,
+    "wmp-4tm-txn": 2337285,
+    "wmp-ref-uk5": 2328369,
+    "wmp-6zl-s7t": 2334316,
+    "wmp-7nw-dl3": 2342831,
+    "wmp-c2n-4z8": 2286938,
+    "wmp-398-75z": 2244737,
+    "wmp-s8l-2hr": 2338603,
+    "wmp-u5x-mu9": 2263459,
+    "wmp-ldb-szm": 2283622,
+    "wmp-mxs-sw9": 2286784,
+    "wmp-ch2-zcl": 2297777,
+    "wmp-awp-bkp": 2291951,
+    "wmp-3zp-hwl": 2318913,
+    "wmp-8cv-768": 2341576,
   };
 
   const task = {
@@ -63,50 +72,61 @@ export const up = async (db, client) => {
 
   const collection = "cases";
 
-  withTransaction(async (session) => {
-    Object.keys(refs).forEach(async (key) => {
+  await withTransaction(async (session) => {
+    for (const [caseRef, ref] of Object.entries(refs)) {
       const kase = await db
         .collection(collection)
-        .findOne({ "payload.identifiers.sbi": key });
+        .findOne({ caseRef, workflowCode: "woodland" }, { session });
 
-      if (kase) {
-        const stage = kase.phases
-          .find((phase) => phase.code === "PHASE_PRE_AWARD")
-          ?.stages.find((stage) => stage.code === "STAGE_AGREEMENT_ACCEPTED");
-
-        if (stage) {
-          const taskGroup = stage.taskGroups && stage.taskGroups[0];
-          const date = new Date().toISOString();
-          if (taskGroup) {
-            taskGroup?.tasks?.unshift({
-              ...task,
-              value: refs[key],
-              updatedAt: date,
-            });
-
-            kase.timeline?.unshift({
-              ...timelineEntry,
-              createdAt: date,
-              data: {
-                caseRef: kase.caseRef,
-              },
-            });
-            await db
-              .collection(collection)
-              .updateOne(
-                { "payload.identifiers.sbi": key },
-                { $set: { phases: kase.phases, timeline: kase.timeline } },
-                { session },
-              );
-          }
-        } else {
-          console.warn(
-            `Stage STAGE_AGREEMENT_UPDATED not found on Case with sbi ${key}.`,
-          );
-        }
-      } else {
-        console.warn(`Case with sbi ${key} was not found.`);
+      if (!kase) {
+        console.warn(`Case with caseRef ${caseRef} was not found.`);
+        continue;
       }
-    });
+
+      const stage = kase.phases
+        .find((phase) => phase.code === "PHASE_PRE_AWARD")
+        ?.stages.find((stage) => stage.code === "STAGE_AGREEMENT_ACCEPTED");
+
+      if (!stage) {
+        console.warn(
+          `Stage STAGE_AGREEMENT_ACCEPTED not found on Case with caseRef ${caseRef}.`,
+        );
+        continue;
+      }
+
+      const taskGroup = stage.taskGroups?.[0];
+
+      if (!taskGroup) {
+        continue;
+      }
+
+      if (taskGroup.tasks?.some((t) => t.code === task.code)) {
+        continue;
+      }
+
+      const date = new Date().toISOString();
+
+      taskGroup.tasks?.unshift({
+        ...task,
+        value: String(ref),
+        updatedAt: date,
+      });
+
+      kase.timeline?.unshift({
+        ...timelineEntry,
+        createdAt: date,
+        data: {
+          caseRef: kase.caseRef,
+        },
+      });
+
+      await db
+        .collection(collection)
+        .updateOne(
+          { caseRef, workflowCode: "woodland" },
+          { $set: { phases: kase.phases, timeline: kase.timeline } },
+          { session },
+        );
+    }
   });
 };

--- a/migrations/20260806101443-wmp-add-siti-agri-ref.js
+++ b/migrations/20260806101443-wmp-add-siti-agri-ref.js
@@ -6,9 +6,10 @@ export const up = async (db) => {
 
     // develop
     "wmp-967-b2u": 2222222, // is accepted
-
+    "wmp-xph-rym": 2222222, // not at accepted stage
     // test
     "wmp-zum-ypr": 3333333, // is accepted
+    "wmp-4db-8ra": 3333333, // not at accepted stage
 
     // prod
     "wmp-l8r-329": 2326337,

--- a/migrations/20260806101443-wmp-add-siti-agri-ref.js
+++ b/migrations/20260806101443-wmp-add-siti-agri-ref.js
@@ -1,0 +1,112 @@
+import { withTransaction } from "../src/common/with-transaction.js";
+
+export const up = async (db, client) => {
+  const refs = {
+    106241643: "2326337",
+    106323196: "2348574",
+    106490576: "2305310",
+    106553297: "2342972",
+    106634181: "2337697",
+    106668514: "2338801",
+    106692400: "2338146",
+    106776150: "2298162",
+    106933321: "2295123",
+    106969836: "2341558",
+    107006764: "2320439",
+    107059405: "2339149",
+    107082687: "2314222",
+    107124756: "2286716",
+    107138876: "2315984",
+    110192152: "2338513",
+    110327815: "2332924",
+    110545261: "2337012",
+    114352085: "2342146",
+    116623145: "2323988",
+    117570918: "2265948",
+    117571851: "2265872",
+    122259669: "2337691",
+    200008255: "2337285",
+    200105772: "2328369",
+    200628182: "2334316",
+    200922657: "2342831",
+    200927219: "2286938",
+    201109197: "2244737",
+    201115195: "2338603",
+    201117357: "2263459",
+    201127086: "2283622",
+    201127543: "2286784",
+    201128065: "2297777",
+    201130003: "2291951",
+    201141756: "2318913",
+    201145088: "2341576",
+  };
+
+  const task = {
+    code: "TASK_SITI_REFERENCE",
+    value: "",
+    completed: true,
+    updatedAt: "",
+    updatedBy: "System",
+    commentRefs: [],
+  };
+
+  const timelineEntry = {
+    createdAt: "",
+    eventType: "TASK_COMPLETED",
+    createdBy: "System",
+    commentRef: null,
+    description: "SitiAgri FC Reference",
+    data: {
+      caseRef: "",
+    },
+  };
+
+  const collection = "cases";
+
+  withTransaction(async (session) => {
+    Object.keys(refs).forEach(async (key) => {
+      const kase = await db
+        .collection(collection)
+        .findOne({ "payload.identifiers.sbi": key });
+
+      if (kase) {
+        const stage = kase.phases
+          .find((phase) => phase.code === "PHASE_PRE_AWARD")
+          ?.stages.find((stage) => stage.code === "STAGE_AGREEMENT_ACCEPTED");
+
+        if (stage) {
+          const taskGroup = stage.taskGroups && stage.taskGroups[0];
+          const date = new Date().toISOString();
+          if (taskGroup) {
+            taskGroup?.tasks?.unshift({
+              ...task,
+              value: refs[key],
+              updatedAt: date,
+            });
+
+            kase.timeline?.unshift({
+              ...timelineEntry,
+              createdAt: date,
+              data: {
+                caseRef: kase.caseRef,
+              },
+            });
+            await db
+              .collection(collection)
+              .updateOne(
+                { "payload.identifiers.sbi": key },
+                { $set: { phases: kase.phases, timeline: kase.timeline } },
+                { session },
+              );
+          }
+        } else {
+          console.warn(
+            `Stage STAGE_AGREEMENT_UPDATED not found on Case with sbi ${key}.`,
+          );
+        }
+      } else {
+        console.warn(`Case with sbi ${key} was not found.`);
+      }
+    });
+  });
+};

--- a/migrations/20260806101443-wmp-add-siti-agri-ref.js
+++ b/migrations/20260806101443-wmp-add-siti-agri-ref.js
@@ -2,8 +2,6 @@ import { withTransaction } from "../src/common/with-transaction.js";
 
 export const up = async (db) => {
   const refs = {
-    "wood-1001": 1010101,
-
     // develop
     "wmp-967-b2u": 2222222, // is accepted
     "wmp-xph-rym": 2222222, // not at accepted stage

--- a/scripts/publish-create-new-case.js
+++ b/scripts/publish-create-new-case.js
@@ -348,6 +348,7 @@ const messageWMPCase = {
     createdAt: "2026-06-08T17:02:59.660Z",
 
     payload: {
+      configVersion: "1.0.1",
       createdAt: "2026-06-08T17:02:59.402Z",
       submittedAt: "2026-06-08T17:02:59.330Z",
 

--- a/src/cases/schemas/task.schema.js
+++ b/src/cases/schemas/task.schema.js
@@ -20,7 +20,15 @@ const compilablePattern = Joi.string().custom((value, helpers) => {
 
 export const InputSchema = Joi.object({
   type: Joi.string().valid("text", "number", "date").required(),
-  label: Joi.string().required(),
+  label: Joi.alternatives()
+    .try(
+      Joi.string(),
+      Joi.object({
+        text: Joi.string().required(),
+        classes: Joi.string().optional(),
+      }),
+    )
+    .required(),
   hint: Joi.array().items(Joi.string()).optional(),
 
   // text only. No placeholder: the GOV.UK Design System says not to use it for

--- a/src/cases/schemas/task.schema.test.js
+++ b/src/cases/schemas/task.schema.test.js
@@ -166,6 +166,41 @@ describe("Task Schema", () => {
     );
   });
 
+  it("should allow object label on an input", () => {
+    const task = {
+      code: "TASK_1",
+      name: "Test task",
+      mandatory: true,
+      description: null,
+      input: {
+        type: "text",
+        label: {
+          text: "Enter SitiAgri reference",
+          classes: "govuk-label--m",
+        },
+      },
+    };
+
+    const { error } = Task.validate(task);
+    expect(error).toBeUndefined();
+  });
+
+  it("should error when an object input label has no text", () => {
+    const task = {
+      code: "TASK_1",
+      name: "Test task",
+      mandatory: true,
+      description: null,
+      input: {
+        type: "text",
+        label: { classes: "govuk-label--m" },
+      },
+    };
+
+    const { error } = Task.validate(task);
+    expect(error).toBeDefined();
+  });
+
   it("should accept a valid input pattern", () => {
     const task = {
       code: "TASK_1",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-1268

**needs**: https://github.com/DEFRA/grants-config-woodland/pull/106

- Backfills Siti Agri reference ids for specific cases (via SBI)
- Adds config seed for woodland
- Update task.schema to allow css and text for label (to match design on ticket)

<img width="1040" height="803" alt="Screenshot 2026-08-06 at 16 16 50" src="https://github.com/user-attachments/assets/7f8d660e-d0cc-4024-9550-dc2c7e566806" />

and after Ref is added (note agreement id in header)

<img width="1020" height="780" alt="Screenshot 2026-08-06 at 16 18 42" src="https://github.com/user-attachments/assets/c64d4446-625b-4b79-a967-04101d052d53" />
